### PR TITLE
⚡ Bolt: Prevent unnecessary list re-renders

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,7 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +57,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // Memoize the toggle function to prevent unnecessary re-renders of BreathingContainer components
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` function with `useCallback` in `App.js`.
🎯 Why: Prevents unnecessary re-renders of all `BreathingContainer` list items when a single intention is toggled.
📊 Impact: Reduces re-renders significantly for list items, providing a smoother user experience, particularly as the list grows or animations run.
🔬 Measurement: Verify by adding a `console.log` inside `BreathingContainer` and observing that it now only logs for the specific item being clicked, instead of all four items simultaneously.

---
*PR created automatically by Jules for task [15912746553281868256](https://jules.google.com/task/15912746553281868256) started by @hkners*