### PR TITLE
🎨 Palette: Add explicit accessibility traits to BreathingContainer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Custom Interactive Elements Need Explicit Accessibility
+**Learning:** In React Native, custom interactive elements (like `TouchableOpacity` mimicking a checkbox) do not automatically convey their role and state to screen readers.
+**Action:** Always explicitly declare native accessibility features by including `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` for custom interactive components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={`Double tap to mark as ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added explicitly declared `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom `TouchableOpacity` component used for checklist items in `App.js`. Also documented this accessibility requirement for custom interactive components in React Native.
🎯 **Why:** Custom interactive components mimicking native controls (like checkboxes) don't automatically communicate their state to screen readers. Explicit declarations make the UI accessible and navigable by users relying on assistive technologies.
♿ **Accessibility:** The intention items are now correctly announced as checkboxes, narrate their checked/unchecked states, and provide instructions on how to interact with them via double tap.

---
*PR created automatically by Jules for task [3376669434023440053](https://jules.google.com/task/3376669434023440053) started by @hkners*