### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders in intention list

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,11 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization:
+// Wrapped in React.memo to prevent unnecessary re-renders of all intention items
+// when only a single item is toggled. This reduces React reconciliation overhead.
+// Expected Impact: Reduces re-renders of unaffected items by 100% when one is toggled.
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +61,21 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization:
+  // Wrapped in useCallback so the function reference remains stable across renders.
+  // This is required for React.memo on BreathingContainer to work effectively.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** Added `React.memo` to the `BreathingContainer` component and wrapped the `toggleIntention` function in `useCallback` inside `App.js`.
🎯 **Why:** To prevent all unaffected intention items from unnecessarily re-rendering whenever a single item is toggled. Without this, toggling any intention changes the `intentions` state, which causes `App` to re-render, creating a new function reference for `toggleIntention` and forcing every child component in the `map` loop to re-render.
📊 **Impact:** Reduces re-renders of unaffected items by 100% when one is toggled. This dramatically reduces React reconciliation overhead and leads to better performance on less capable mobile devices.
🔬 **Measurement:** Use React Developer Tools Profiler to observe the "Highlight updates when components render" feature. Without this optimization, the entire list flashes. With it, only the specific toggled intention item flashes.

---
*PR created automatically by Jules for task [10873897918915267803](https://jules.google.com/task/10873897918915267803) started by @hkners*