### PR TITLE
🎨 Palette: Add accessibility roles and states to intention checkboxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-08 - Accessible Custom Checkboxes in React Native
+**Learning:** Custom interactive elements that behave like checkboxes (e.g., TouchableOpacity wrapping text) require explicit native accessibility features for screen readers to interpret them correctly. Relying solely on visual cues or generic "button" roles is insufficient.
+**Action:** Always include `accessibilityRole="checkbox"`, `accessibilityState={{ checked: isChecked }}`, and descriptive `accessibilityLabel`/`accessibilityHint` props when building custom toggleable components in React Native.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Toggles the ${intention.title} intention`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
## 🎨 Palette: Accessibility Roles for Intentions

### 💡 What
Added native React Native accessibility properties (`accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the custom `TouchableOpacity` component used for toggling daily intentions in `App.js`. 

I also created `.Jules/palette.md` to journal the critical learning that custom interactive elements requiring checkbox behavior need explicitly declared native accessibility features.

### 🎯 Why
Screen readers (like VoiceOver and TalkBack) will now correctly announce the `BreathingContainer` item as a checkbox, its checked state, its label, and its toggle action. Previously, it was announced only as a generic clickable element without context, making it inaccessible to visually impaired users.

### ♿ Accessibility
- `accessibilityRole="checkbox"` properly identifies the semantic role.
- `accessibilityState={{ checked: intention.completed }}` keeps the screen reader in sync with visual changes.
- `accessibilityLabel={intention.title}` provides the content text.
- `accessibilityHint="Toggles the intention status"` explains the interaction.

---
*PR created automatically by Jules for task [12673920322898222840](https://jules.google.com/task/12673920322898222840) started by @hkners*