### PR TITLE
⚡ Bolt: Prevent unnecessary list item re-renders

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders when other items in the list change.
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped in useCallback to preserve function reference across renders, ensuring React.memo on children works correctly.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` function using `useCallback`.
🎯 **Why:** To prevent unnecessary re-renders of the entire intention list when a single item's state changes (toggled on or off). Previously, toggling one item caused all items to re-render because `toggleIntention` was recreated on every render of `App.js`.
📊 **Impact:** Reduces O(n) re-renders to O(1) when interacting with list items, making interactions smoother.
🔬 **Measurement:** Use React DevTools Profiler to record interaction while toggling an intention. Before: all `BreathingContainer`s show as re-rendered. After: only the toggled `BreathingContainer` shows as re-rendered.

---
*PR created automatically by Jules for task [1339415583317011758](https://jules.google.com/task/1339415583317011758) started by @hkners*