### PR TITLE
🎨 Palette: Add accessibility roles to BreathingContainer toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Accessibility Roles for Custom Checkboxes
+**Learning:** In React Native, custom interactive elements (like `TouchableOpacity` mimicking a checkbox) must explicitly declare native accessibility features by including `accessibilityRole`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` or `accessibilityHint` to be properly interpreted by screen readers.
+**Action:** Always verify that custom UI elements performing standard roles (e.g., toggles, checkboxes) are equipped with the corresponding native accessibility attributes.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={intention.completed ? "Double tap to mark as incomplete" : "Double tap to mark as complete"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added React Native accessibility features (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) to the `TouchableOpacity` component in `BreathingContainer`.
🎯 Why: The component acts as a custom checkbox for intentions, but without native accessibility properties, it is invisible and uninterpretable by screen readers. This change ensures screen reader users can interact with and understand the state of their daily intentions.
📸 Before/After: Visual UI is unaffected as this is an invisible accessibility change.
♿ Accessibility: Fully enables screen reader support for the primary interactive element.
📓 Journal: Documented the learning regarding custom interactive elements and native accessibility roles in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [9080039585317160992](https://jules.google.com/task/9080039585317160992) started by @hkners*