### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-10 - Custom Interactive Accessibility
+**Learning:** Custom interactive elements mimicking checkboxes (like TouchableOpacity) in React Native require explicit native accessibility features (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, etc.) to be properly announced by screen readers and properly reflect their state.
+**Action:** Always add `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to interactive components that toggle state.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added native accessibility properties (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the `TouchableOpacity` component in `App.js` which is used to toggle the completion status of intentions. Also created `.Jules/palette.md` to document this critical accessibility learning.

🎯 **Why:** Custom interactive elements mimicking checkboxes in React Native are not inherently understood by screen readers. These explicit properties ensure the component correctly announces its role ("checkbox"), its current state (checked or unchecked), what the component represents (the intention title), and a hint on how to interact with it, drastically improving usability for visually impaired users relying on screen readers.

📸 **Before/After:** No visual changes. See screenshot attached for confirmation that the clean aesthetic is perfectly preserved.

♿ **Accessibility:** Added native accessibility props to custom `TouchableOpacity` mimicking a checkbox state toggle.

---
*PR created automatically by Jules for task [17987159406556233886](https://jules.google.com/task/17987159406556233886) started by @hkners*