### PR TITLE
⚡ Bolt: Optimize list re-renders and prevent animation memory leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React Native Animated.loop Memory Leaks
+**Learning:** In React Native, `Animated.loop` does not automatically stop or clean itself up when the component unmounts or when dependency arrays in `useEffect` change. This can lead to memory leaks and unnecessary background thread activity. Also, mapping list components without `React.memo` causes O(n) re-rendering.
+**Action:** Always capture the reference returned by `Animated.loop` and explicitly call `.stop()` in the `useEffect` cleanup function. Additionally, wrap custom row components in `React.memo` and pass stable callback props using `useCallback` to prevent unnecessary re-renders.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,16 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrap component in React.memo to prevent O(n) re-renders
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let loopAnim;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt Optimization: Capture loop reference and stop on unmount/dependency change
+      // to prevent memory leaks and background thread activity
+      loopAnim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +31,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      loopAnim.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (loopAnim) {
+        loopAnim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +68,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize callback to prevent breaking React.memo on child components
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** 
- Wrapped the custom `BreathingContainer` row component in `React.memo()`.
- Memoized the `toggleIntention` callback function passed to list items using `useCallback`.
- Captured the `Animated.loop` instance and explicitly called `.stop()` on it in the component's `useEffect` cleanup return function.

🎯 **Why:**
- When updating state in React Native (like toggling completion on one item), every item in the `map()` loop was being fully re-rendered because they were passing un-memoized callbacks and weren't wrapped in `React.memo`. This is an `O(n)` render bottleneck that slows down large lists.
- `Animated.loop` does not automatically stop running when a component unmounts or when the `useEffect` dependency array changes. In the original code, toggling a high-priority intention would create a zombie background animation thread, eventually leading to a memory leak and performance degradation.

📊 **Impact:** 
- **Reduces re-renders by 100% for unaffected rows**: Only the specific item toggled will now re-render, turning an `O(n)` operation into an `O(1)` operation.
- **Prevents Memory Leaks**: Stops background threads from holding onto unused `Animated` instances when intentions are completed or removed.

🔬 **Measurement:** 
- Verified using `node -c` (Syntax Check).
- Ran local Expo web instance (`pnpm run web`) and visually validated via Playwright screenshots to guarantee there were no regressions.
- Logged the specific React Native `Animated.loop` learning into `.jules/bolt.md`.

---
*PR created automatically by Jules for task [2063894023138150754](https://jules.google.com/task/2063894023138150754) started by @hkners*