### PR TITLE
🎨 Palette: Add accessibility to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-13 - Added explicitly defined accessibility states for custom interactive components.
+**Learning:** When using custom React Native components (like TouchableOpacity) to mimic checkboxes, they must explicitly declare native accessibility features. Providing `accessibilityRole="checkbox"` helps screen readers understand the component, while `accessibilityState={{ checked: ... }}` communicates its current toggle state to users.
+**Action:** Always include `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` when creating interactive elements that don't use platform default semantic tags to ensure full accessibility support.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added comprehensive accessibility properties to the custom `TouchableOpacity` component used for intention toggles.
🎯 **Why:** Custom interactive components do not inherently expose their semantic meaning or state to assistive technologies. By adding explicit properties, users relying on screen readers can now understand what the element does and its current checked state.
📸 **Before/After:** No visual changes.
♿ **Accessibility:**
- Added `accessibilityRole="checkbox"` to give semantic meaning.
- Added `accessibilityState={{ checked: intention.completed }}` to dynamically announce the toggle state.
- Added `accessibilityLabel={intention.title}` to announce the content.
- Added `accessibilityHint="Toggles the completion status of this intention"` to clarify action.

---
*PR created automatically by Jules for task [16100494383175047108](https://jules.google.com/task/16100494383175047108) started by @hkners*