### PR TITLE
🎨 Palette: Improve accessibility of intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve accessibility of intention toggles
+**Learning:** In React Native, custom interactive elements (like `TouchableOpacity` mimicking a checkbox) must explicitly declare native accessibility features to be usable by screen readers. A simple pressable area is not enough.
+**Action:** When using `TouchableOpacity` or similar components as custom UI elements (like checkboxes, radios, or switches), always explicitly set `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` or `accessibilityHint`.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Double tap to toggle completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibility features (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) to the custom `TouchableOpacity` mimicking a checkbox in `BreathingContainer`.
🎯 Why: Custom interactive elements in React Native aren't automatically read correctly by screen readers. A user needs to know it acts as a checkbox and its current state.
📸 Before/After: Visuals remain identically "clean girl" minimal, but accessibility is drastically improved under the hood.
♿ Accessibility: Screen readers will now correctly identify the element as a checkbox, announce its text label, read its checked/unchecked state, and provide the correct hint on how to interact.

---
*PR created automatically by Jules for task [2566221216126493401](https://jules.google.com/task/2566221216126493401) started by @hkners*