### PR TITLE
⚡ Bolt: Prevent O(n) rendering and memory leaks in intention list

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Prevent Memory Leaks from Animated.loop in React Native
+
+**Learning:** I noticed that using `Animated.loop` in a `useEffect` hook without capturing its reference and calling `.stop()` on component unmount or state change creates a background memory leak, as the animation thread continues running indefinitely.
+
+**Action:** Always assign `Animated.loop` to a variable inside `useEffect` and return a cleanup function that checks if the animation is truthy before calling `.stop()` on it.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,13 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let loopAnim = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      loopAnim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +28,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      loopAnim.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (loopAnim) {
+        loopAnim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +65,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** 
- Wrapped `BreathingContainer` in `React.memo` and the `toggleIntention` handler in `useCallback`.
- Added a cleanup function to `Animated.loop` in `BreathingContainer`'s `useEffect`.
- Recorded learning in `.jules/bolt.md`.

🎯 **Why:** 
- Toggling a single intention re-rendered the entire list of `BreathingContainer`s because `toggleIntention` was recreated on every render and the components weren't memoized, causing O(n) rendering work.
- `Animated.loop` was running indefinitely even after the component unmounted or its dependencies changed, causing a background memory leak and CPU usage.

📊 **Impact:** 
- Reduces unnecessary re-renders when toggling an item from O(n) to O(1).
- Prevents indefinite background memory leaks and thread activity.

🔬 **Measurement:** 
- Verified via `git status`, `node -c App.js`, and Playwright test script interacting with the toggles to ensure the optimizations do not break functionality.

---
*PR created automatically by Jules for task [6288062926425803381](https://jules.google.com/task/6288062926425803381) started by @hkners*