### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Added Accessibility Attributes to TouchableOpacity Checkbox
+**Learning:** Custom interactive elements (like `TouchableOpacity` mimicking a checkbox) must explicitly declare native accessibility features to be accessible to screen readers, especially in this app's "BreathingContainer" where state changes are vital.
+**Action:** When building custom toggle components or checkboxes in React Native, always include `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` or `accessibilityHint` so screen readers properly announce the element's purpose and state.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the intention status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added explicitly `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` attributes to the custom `TouchableOpacity` toggle components in `App.js`.
🎯 Why: Custom interactive elements (like `TouchableOpacity` mimicking a checkbox) must explicitly declare native accessibility features to be accessible and effectively used by screen readers. By adding these standard accessibility props, screen readers can now properly announce the element's purpose and state to visually impaired users.
📸 Before/After: Visual presentation remains identical, maintaining the clean aesthetic. Screen reader behavior is improved.
♿ Accessibility: The elements are now properly treated as accessible checkable items.

---
*PR created automatically by Jules for task [2775804194240689566](https://jules.google.com/task/2775804194240689566) started by @hkners*