### PR TITLE
🎨 Palette: Add accessibility roles to custom checkboxes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-18 - Missing Accessibility on Custom Checkboxes
+**Learning:** In React Native, custom interactive elements (like `TouchableOpacity` mimicking a checkbox) must explicitly declare native accessibility features to be usable by screen readers. A standard `TouchableOpacity` doesn't convey its state or purpose without `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint`.
+**Action:** Always add `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` or `accessibilityHint` to custom toggle components so that they announce their current state properly.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={`Double tap to toggle intention ${intention.completed ? 'off' : 'on'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
### 💡 What:
Added explicit `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, `accessibilityLabel`, and `accessibilityHint` properties to the `TouchableOpacity` component used for toggling daily intentions.

### 🎯 Why:
The `TouchableOpacity` was functioning as a custom checkbox but lacked native accessibility properties. Without these, screen readers would not announce the element's current state (checked/unchecked) or its purpose, leading to poor usability for visually impaired users. This change ensures the interaction is semantically correct and fully accessible.

### ♿ Accessibility:
- Added `accessibilityRole="checkbox"` to convey the element's purpose.
- Added `accessibilityState={{ checked: intention.completed }}` to dynamically announce the element's state.
- Added `accessibilityLabel` using the intention title for context.
- Added `accessibilityHint` to provide clear instruction on interaction.

### 📸 Before/After:
No visual changes. This is a purely non-visual accessibility enhancement.

---
*PR created automatically by Jules for task [17155443270224576373](https://jules.google.com/task/17155443270224576373) started by @hkners*