### PR TITLE
⚡ Bolt: Prevent O(n) re-renders and animation memory leaks in intentions list

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Animated.loop Memory Leaks in Lists
+**Learning:** In React Native list items with continuous animations (`Animated.loop`), failing to explicitly capture the animation reference and calling `.stop()` on unmount/dependency change causes silent memory leaks and background thread CPU usage, which becomes worse as items map.
+**Action:** Always capture the reference returned by `Animated.loop` and explicitly call its `.stop()` method inside the `useEffect` cleanup function.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,14 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Prevent O(n) re-renders for unchanged intentions by memoizing the row component
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Explicitly capture reference and call .stop() on unmount to prevent memory leaks and background thread CPU usage
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +67,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Stable callback prop for onToggle using useCallback and functional state updates prevents unnecessary re-renders of all rows
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** 
- Wrapped the list row component (`BreathingContainer`) in `React.memo` to prevent re-rendering unchanged list items.
- Used `useCallback` with a functional state update to provide a stable reference for the `onToggle` prop.
- Captured the `Animated.loop` instance and explicitly called `.stop()` in the `useEffect` cleanup function.
- Added inline comments and recorded the `Animated.loop` memory leak learning in `.jules/bolt.md`.

🎯 **Why:** 
Previously, every time an intention was toggled, all list items would re-render because `toggleIntention` had a new reference and `BreathingContainer` wasn't memoized. Additionally, the continuous `Animated.loop` in the list items wasn't properly terminated on unmount or dependency change, leading to background CPU utilization and memory leaks as items mapped/mounted.

📊 **Impact:** 
- Reduces unnecessary component re-renders by 100% for unchanged intention items (O(1) instead of O(n)).
- Prevents silent memory leaks and high CPU background usage caused by orphan animations.

🔬 **Measurement:** 
- Visually verify through Expo: The app continues to behave correctly with no visual regressions.
- Developer Tools Profiler: Toggling an item will no longer trigger re-renders for the other items in the list.

---
*PR created automatically by Jules for task [16719373792250215545](https://jules.google.com/task/16719373792250215545) started by @hkners*