### PR TITLE
🎨 Palette: Make custom checkboxes accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-19 - Accessible Checkboxes in React Native
+**Learning:** Custom interactive elements like `TouchableOpacity` mimicking a checkbox require explicitly declaring native accessibility features to be usable by screen readers, as they don't inherit default checkbox semantics like web elements do.
+**Action:** Always include `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` when using `TouchableOpacity` to create custom checkbox-like toggles in React Native.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to toggle intention ${intention.title}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added screen reader accessibility traits (`accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the custom intention toggle buttons. Also started logging critical UX/a11y learnings to `.Jules/palette.md`.

🎯 Why: Custom interactive elements like `TouchableOpacity` mimicking a checkbox require explicit native accessibility features to be usable by screen readers, otherwise they appear as generic, uninformative buttons.

📸 Before/After: Visuals remain unchanged (confirmed via screenshot verification).

♿ Accessibility: The intention items are now properly announced as checkboxes to screen readers (VoiceOver/TalkBack), and their checked state is dynamically communicated. Users will also hear a hint on how to interact with them.

---
*PR created automatically by Jules for task [18112049282298462963](https://jules.google.com/task/18112049282298462963) started by @hkners*