### PR TITLE
🎨 Palette: Add semantic accessibility to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Semantic Accessibility for React Native Intention Toggles
+**Learning:** React Native custom interactive elements (like `TouchableOpacity` acting as a checkbox) lack explicit native accessibility roles and states. If a visually-impaired user uses a screen reader, they might hear "Morning Meditation" but not know it acts like a checkbox.
+**Action:** Always add semantic accessibility features (`accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, `accessibilityLabel`) to components that functionally mimic native accessible inputs.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Tap to mark ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
**💡 What:**
Added explicit accessibility roles and states to the `TouchableOpacity` component used for intention toggles in `App.js`.

**🎯 Why:**
Since `TouchableOpacity` does not natively represent a checkbox, screen readers could not properly convey its function or state (checked/unchecked) to visually impaired users. This change provides proper semantics, improving the usability of the primary interaction without affecting visual users.

**📸 Before/After:**
*(No visual changes - purely semantic accessibility improvements in the accessibility tree)*

**♿ Accessibility:**
- Added `accessibilityRole="checkbox"` to clarify function.
- Added `accessibilityState={{ checked: intention.completed }}` to dynamically reflect status.
- Added `accessibilityLabel` for the primary intention text.
- Added `accessibilityHint` to provide context on what tapping does based on current state.

*Journal note added to .Jules/palette.md regarding React Native custom interactive component accessibility.*

---
*PR created automatically by Jules for task [14130318639438662211](https://jules.google.com/task/14130318639438662211) started by @hkners*