### PR TITLE
🎨 Palette: Add accessibility semantics to custom checkbox

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility on Custom Interactive Elements
+**Learning:** In React Native, custom interactive elements (e.g., `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning and must explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint` for assistive technologies.
+**Action:** Always add semantic accessibility attributes to custom components like `TouchableOpacity` or `Pressable` that function as standard UI controls.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={intention.completed ? "Double tap to mark as incomplete" : "Double tap to mark as complete"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added missing semantic attributes (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) to the `TouchableOpacity` functioning as a checkbox component in `App.js`.
🎯 **Why:** Custom interactive elements (like `TouchableOpacity`) lack inherent semantic meaning, making them inaccessible to screen readers without explicit ARIA-like attributes. This change ensures the intentions can be properly navigated and understood via assistive technologies.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now correctly announce the component as a checkbox, communicate its checked state, label the intention by title, and provide a hint on how to interact with it.

---
*PR created automatically by Jules for task [5253169566689942349](https://jules.google.com/task/5253169566689942349) started by @hkners*