### PR TITLE
🎨 Palette: Add accessibility attributes to intentions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - explicit accessibility props on touchables
+**Learning:** In React Native, custom interactive elements constructed with components like `TouchableOpacity` do not automatically convey semantic meaning to assistive technologies like screen readers. When acting as a checkbox (toggling state), screen readers might only announce "Button" without the component's current state.
+**Action:** Always provide `accessibilityRole` (e.g., `"checkbox"`), `accessibilityState` (e.g., `{ checked: boolean }`), `accessibilityLabel`, and an `accessibilityHint` to clarify the component's purpose and state to users with assistive technology when building custom interactive touchable elements.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
**💡 What:** 
Added explicit accessibility properties (`accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the custom `TouchableOpacity` intention components in `App.js`.

**🎯 Why:**
Because these touchables act as checkboxes (toggling completed state), without an explicit role and state, screen readers simply announce them as generic buttons. This leaves users relying on assistive technologies without context of the component's state or purpose.

**📸 Before/After:**
*Visuals remain unchanged as these are structural accessibility props.*

**♿ Accessibility:**
* Added `accessibilityRole="checkbox"` to convey the semantic purpose.
* Added `accessibilityState={{ checked: intention.completed }}` to communicate the current toggle state dynamically.
* Added `accessibilityLabel` using the intention title.
* Added `accessibilityHint` to inform the user what interacting with the element will do.

---
*PR created automatically by Jules for task [14022940567676701804](https://jules.google.com/task/14022940567676701804) started by @hkners*