### PR TITLE
⚡ Bolt: Prevent memory leaks and O(n) re-renders in list animations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Prevent Memory Leaks and O(n) re-renders in List Animations
+**Learning:** Found an issue where React Native's `Animated.loop` would leak memory and potentially block the background thread because it lacked an explicit `.stop()` call upon component unmount or state transitions. Additionally, the `BreathingContainer` row component inside the list re-rendered on every list state update, creating O(n) work for the render loop instead of O(1).
+**Action:** Always capture the `Animated.loop` return value and invoke `.stop()` in the `useEffect` cleanup function. Wrap mapped row components with `React.memo()` and use `useCallback` for their event handlers to prevent unnecessary re-renders when list data changes.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, memo, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,16 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt Optimization: Capture the loop reference to stop it properly on unmount
+    // or when the condition becomes false, preventing memory leaks and background thread work.
+    let animationLoop = null;
+
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animationLoop = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +31,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animationLoop.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animationLoop) {
+        animationLoop.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +68,21 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Use useCallback with a functional state update to prevent
+  // recreating this function on every render, which in turn prevents the memoized
+  // BreathingContainer items from re-rendering in an O(n) fashion.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** 
- Captured the `Animated.loop` reference within `BreathingContainer` and added an explicit `.stop()` call in the `useEffect` cleanup block.
- Wrapped the mapped `BreathingContainer` row component in `React.memo()`.
- Wrapped the `toggleIntention` state setter function in `useCallback` with a functional state update.

🎯 **Why:** 
React Native's `Animated.loop` animations will persist infinitely and leak memory/consume background thread resources if not explicitly stopped when the component unmounts or the triggering condition becomes false.
Additionally, passing inline functions or non-memoized handlers to row components in a map loop forces React to re-render every item in the list whenever the parent state changes, creating an O(n) performance bottleneck for what should be an O(1) row update.

📊 **Impact:** 
- **Eliminates background thread hogging and memory leaks** for completed intention containers.
- **Reduces re-renders from O(n) to O(1)** when a user toggles a single intention from the list.

🔬 **Measurement:** 
Run the application and toggle an intention item. You can observe using the React DevTools Profiler that only the specific toggled `BreathingContainer` row re-renders, rather than the entire list re-rendering. You can also monitor JS thread memory consumption to see it remains stable as items are completed/removed.

---
*PR created automatically by Jules for task [10547454490479558691](https://jules.google.com/task/10547454490479558691) started by @hkners*