### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility Roles for Custom Interactive Elements
+**Learning:** Custom interactive elements like `TouchableOpacity` in React Native lack inherent semantic meaning and must explicitly declare accessibility attributes (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) for screen readers to properly interpret them.
+**Action:** Always add semantic accessibility props to custom touchable wrappers, especially when they behave like standard native controls (e.g., checkboxes, switches).

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Double tap to toggle completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added comprehensive accessibility attributes to the custom `TouchableOpacity` component used for toggling intentions.
🎯 **Why:** `TouchableOpacity` lacks inherent semantic meaning. Without these attributes, screen readers cannot properly interpret the element as a toggleable checkbox, making the application inaccessible to visually impaired users.
📸 **Before/After:** No visual changes.
♿ **Accessibility:**
- Added `accessibilityRole="checkbox"` to convey the element's purpose.
- Added `accessibilityState={{ checked: intention.completed }}` to communicate the current state.
- Added `accessibilityLabel={intention.title}` to read the intention text.
- Added `accessibilityHint="Double tap to toggle completion status"` to guide the user on how to interact with it.

---
*PR created automatically by Jules for task [3861113892984308349](https://jules.google.com/task/3861113892984308349) started by @hkners*