### PR TITLE
🎨 Palette: Add accessibility semantics to custom checkbox

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Semantic Accessibility for Custom Checkboxes in React Native
+**Learning:** Custom interactive elements in React Native (like `TouchableOpacity` acting as a checkbox) lack inherent semantic meaning and fail to convey their state or purpose to assistive technologies out of the box.
+**Action:** Always explicitly declare `accessibilityRole` (e.g., "checkbox"), `accessibilityState` (e.g., `{ checked: true/false }`), and provide descriptive `accessibilityLabel` and `accessibilityHint` props when building non-standard interactive components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles completion"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom intention toggle components.
🎯 Why: The intention list uses a `TouchableOpacity` to act like a checkbox. Without explicitly defined semantic roles, assistive technologies (like screen readers) treat it as a generic, unlabeled button, preventing visually impaired users from understanding its purpose or its current completion state.
📸 Before/After: No visual changes. This is an invisible accessibility improvement.
♿ Accessibility:
- Set `accessibilityRole="checkbox"` to accurately convey the interaction model.
- Passed `{ checked: intention.completed }` to `accessibilityState` so the screen reader announces if the intention is completed.
- Added `accessibilityLabel` using the intention title.
- Added `accessibilityHint` to explain the toggle behavior.

---
*PR created automatically by Jules for task [18427900443745952174](https://jules.google.com/task/18427900443745952174) started by @hkners*