### PR TITLE
⚡ Bolt: Memoize BreathingContainer to prevent O(N) re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,1 @@
+# Bolt Journal

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoize BreathingContainer to prevent unnecessary re-renders when other items are toggled.
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Wrap toggleIntention in useCallback to provide a stable reference to memoized BreathingContainer children.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:**
Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` function using `useCallback`.

🎯 **Why:**
Previously, toggling the completion status of a single intention caused all other `BreathingContainer` components in the list to re-render, creating an O(N) re-render bottleneck when the intention array length increased.

📊 **Impact:**
Reduces unnecessary re-renders of list items to O(1) per toggle operation.

🔬 **Measurement:**
Using React DevTools Profiler, when clicking on an intention to toggle its status, observe that only the clicked `BreathingContainer` re-renders, while the other instances skip their render phase.

---
*PR created automatically by Jules for task [7044968447856019557](https://jules.google.com/task/7044968447856019557) started by @hkners*