### PR TITLE
⚡ Bolt: Optimize list rendering with React.memo

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Use React.memo to prevent re-rendering when other intentions change.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Use useCallback to maintain function reference, preventing unnecessary re-renders of BreathingContainer components.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:**
Wrapped the `BreathingContainer` component in `React.memo` and wrapped the `toggleIntention` function in `React.useCallback`.

🎯 **Why:**
Without memoization, every time an individual intention is toggled, its `completed` state changes, triggering a re-render of the parent `App` component. Because the default behavior of React is to re-render all children when a parent re-renders, every single `BreathingContainer` in the list re-rendered, even those whose state didn't change.

📊 **Impact:**
Expected performance improvement: Prevents O(N) re-renders (where N is the number of intentions in the list) on every interaction. Only the specific item being toggled will re-render, reducing unnecessary JavaScript execution and reconciliation overhead significantly.

🔬 **Measurement:**
This can be verified by adding a `console.log('Rendering BreathingContainer', intention.id)` inside the `BreathingContainer` component and observing that only the logged ID matches the item toggled, rather than all IDs being logged on every interaction.

---
*PR created automatically by Jules for task [13704496661386081084](https://jules.google.com/task/13704496661386081084) started by @hkners*