### PR TITLE
🎨 Palette: Add accessibility props to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Custom Checkboxes
+**Learning:** Custom interactive elements in React Native (like `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning for assistive technologies.
+**Action:** Always explicitly declare `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` on custom interactive components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Double tap to toggle intention status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the `TouchableOpacity` used for toggling intentions in `App.js`.
🎯 Why: Custom interactive elements mimicking standard inputs (like checkboxes) do not inherently communicate their role or state to assistive technologies, making the interface difficult for screen reader users to navigate and understand.
📸 Before/After: Visuals remain identically untouched since this is a semantic accessibility change.
♿ Accessibility: Assistive technologies will now properly announce the component as a "checkbox", state its current "checked" status, read the intention title, and provide a hint on how to interact with it.

---
*PR created automatically by Jules for task [9250798981042459073](https://jules.google.com/task/9250798981042459073) started by @hkners*