### PR TITLE
⚡ Bolt: Prevent unnecessary list re-renders

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrap component in React.memo to prevent unnecessary re-renders
+// when other items in the list are toggled.
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize the toggle callback to keep its reference stable
+  // so it doesn't break React.memo on BreathingContainer
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:**
Wrapped the `BreathingContainer` list item component in `React.memo()` and stabilized its `onToggle` prop by wrapping the `toggleIntention` function in `useCallback()`.

🎯 **Why:**
Whenever a single intention was toggled, the state update in `App` caused the entire component to re-render. This recreated the `toggleIntention` function on every render, which in turn caused every single `BreathingContainer` component in the list to re-render, even if its specific intention data hadn't changed. This is a classic React rendering bottleneck for lists.

📊 **Impact:**
Reduces re-renders. Now, toggling an item only re-renders the specific item whose state changed, rather than the entire list. This improves UI responsiveness, especially as the list grows or if the items contain complex internal animations (like `pulseAnim`).

🔬 **Measurement:**
This can be verified by adding a `console.log('Rendering', intention.id)` inside `BreathingContainer` and observing the console output when toggling an item. With this optimization, only the toggled item will log.

---
*PR created automatically by Jules for task [14354902510708527164](https://jules.google.com/task/14354902510708527164) started by @hkners*