### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Custom Interactive Elements Lack Semantics
+**Learning:** In React Native, custom interactive elements (like `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning and are not properly recognized by assistive technologies without explicit attributes.
+**Action:** Always declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint` on custom interactive components like `TouchableOpacity` to ensure they are accessible.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of the intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
What: Added accessibility attributes (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, `accessibilityHint`) to the `TouchableOpacity` toggles in the intention list.
Why: Custom interactive elements in React Native lack inherent semantic meaning, making them inaccessible to screen readers without explicit attributes.
Accessibility: Screen readers can now properly identify the intention toggles as checkboxes, read their labels, and announce their current checked state.

---
*PR created automatically by Jules for task [6297586718619034600](https://jules.google.com/task/6297586718619034600) started by @hkners*