### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -59,16 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
   );
 };
 
+// ⚡ Bolt Optimization: Wrapped BreathingContainer in React.memo to prevent unnecessary re-renders of un-toggled list items. Expected impact: Reduces re-renders of all untouched list items by 100% when one item is toggled.
+const MemoizedBreathingContainer = React.memo(BreathingContainer);
+
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Wrapped toggleIntention in useCallback to keep function reference stable across renders. Expected impact: Works in tandem with React.memo on BreathingContainer to actually prevent re-renders.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -81,7 +85,7 @@ export default function App() {
 
         <View style={styles.listContainer}>
           {intentions.map(intention => (
-            <BreathingContainer
+            <MemoizedBreathingContainer
               key={intention.id}
               intention={intention}
               onToggle={toggleIntention}


### PR DESCRIPTION
💡 **What:**
Wrapped the `BreathingContainer` item component in `React.memo()` and stabilized the `toggleIntention` updater function with a `useCallback` hook in `App.js`. Added inline comments explaining the expected impact.

🎯 **Why:**
Previously, whenever a user toggled the completion state of a single intention item, the state update in `App` would cause the parent to re-render, thus forcing *all* items in the list to re-render unnecessarily.

📊 **Impact:**
Reduces unnecessary re-renders of untouched list items by 100%. When an item is toggled, only the `MemoizedBreathingContainer` associated with that specific item will re-render, making the list rendering significantly more efficient, especially as the list grows.

🔬 **Measurement:**
This can be verified by placing a `console.log` inside `BreathingContainer` and observing the output when clicking an item. Before this PR, all items would log. After this PR, only the toggled item will log. Additionally, I verified the UI interactions remain fully functional using a Playwright script.

---
*PR created automatically by Jules for task [5222116384673247472](https://jules.google.com/task/5222116384673247472) started by @hkners*