### PR TITLE
🎨 Palette: Add accessibility semantics to intention toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-30 - Custom Checkbox Accessibility
+**Learning:** In React Native, custom interactive elements acting as checkboxes (like TouchableOpacity toggling an intention) lack semantic meaning and must explicitly declare accessibilityRole, accessibilityState, and accessibilityLabel/accessibilityHint for assistive technologies.
+**Action:** Always add explicit accessibility roles and states to custom interactive components that function as standard UI elements.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to toggle intention ${intention.completed ? 'off' : 'on'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the intention toggle buttons. 
🎯 Why: Custom interactive elements in React Native lack semantic meaning for screen readers. This ensures assistive technologies correctly announce the component as a checkbox and its current state. 
📸 Before/After: Visuals remain unchanged. 
♿ Accessibility: Screen reader users can now understand the purpose and state of the intention buttons.

---
*PR created automatically by Jules for task [72299303046242996](https://jules.google.com/task/72299303046242996) started by @hkners*