### PR TITLE
⚡ Bolt: Memoize BreathingContainer and toggleIntention

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoize component to prevent unnecessary re-renders of list items
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize function to provide stable reference to child components
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What**: Wrapped the `BreathingContainer` in `React.memo` and wrapped the `toggleIntention` function in `useCallback`.
🎯 **Why**: Previously, any change to a single intention's state (e.g., toggling its completed status) triggered a re-render of the entire `App` component. Because the child components weren't memoized and the toggle function reference changed on every render, React would needlessly re-render every single `BreathingContainer` in the list.
📊 **Impact**: Prevents unnecessary re-renders of list items. When toggling a single intention, only that specific intention will re-render, reducing reconciliation overhead significantly for larger lists.
🔬 **Measurement**: Verified the functional correctness using Playwright. To measure the impact, use the React DevTools Profiler to record a toggle action. Before this change, the profiler would show all list items rendering. After this change, only the toggled item will re-render.

---
*PR created automatically by Jules for task [8396649967948019811](https://jules.google.com/task/8396649967948019811) started by @hkners*