### PR TITLE
🎨 Palette: Add accessibility props to intention toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-31 - Explicit Accessibility Props for Custom Interactive Elements
+**Learning:** In React Native, custom interactive elements (e.g., `TouchableOpacity` functioning as a checkbox or toggle) lack inherent semantic meaning and must explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint` to be properly interpreted by assistive technologies.
+**Action:** Always add explicit accessibility props to `TouchableOpacity` when it acts as a semantic control (like a checkbox or toggle button).

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles intention completion"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom `TouchableOpacity` toggle component in `App.js`. Created `.jules/palette.md` to log a critical learning regarding semantic meaning for custom components in React Native.
🎯 **Why:** To ensure screen readers can accurately interpret the intention item as a toggleable checkbox rather than a generic button, providing crucial context to users who rely on assistive technologies.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Users with screen readers will now hear "Morning Meditation, checkbox, unchecked. Toggles intention completion." (or checked) instead of generic button readouts.

---
*PR created automatically by Jules for task [10687744933100290714](https://jules.google.com/task/10687744933100290714) started by @hkners*