### PR TITLE
⚡ Bolt: Prevent background animation leak and reduce re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-31 - Animated.loop Memory Leak
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the component logically "completes" or its state changes, unless explicitly stopped. This can cause CPU/battery drain if the loop is merely overwritten or ignored rather than explicitly `.stop()`'d when a condition changes.
+**Action:** Always capture the reference returned by `Animated.loop().start()` and ensure `.stop()` is called in the `useEffect` cleanup function or when the loop's condition becomes false.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,17 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders of list items
+// Impact: Reduces re-renders by ~75% when toggling a single item in a list of 4
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let loopAnim;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture the Animated.loop reference to stop it explicitly
+      // Impact: Prevents memory/CPU leak on the native thread when the loop condition becomes false
+      loopAnim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +32,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      loopAnim.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (loopAnim) {
+        loopAnim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +69,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped in useCallback to maintain stable reference for memoized children
+  // Impact: Prevents recreation of the function on every App render
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 **What:** 
1. Wrapped `BreathingContainer` list items in `React.memo` and wrapped the `toggleIntention` function in `useCallback` to prevent unnecessary component recreation during re-renders.
2. Captured the `Animated.loop` reference and explicitly called `.stop()` in the `useEffect` cleanup block to ensure the looping animation is stopped when the condition changes.

🎯 **Why:** 
1. Previously, clicking on a single intention toggled its state and caused the entire `App` and all `BreathingContainer` items to unnecessarily re-render.
2. The `Animated.loop` was configured with `useNativeDriver: true`. When an item was checked off, the condition changed, but the previously started native loop was never explicitly stopped, leading to a silent CPU/memory leak on the native UI thread.

📊 **Impact:** 
1. Reduces re-renders by ~75% for an un-interacted item when another item is clicked (in a list of 4 items).
2. Prevents indefinite background CPU and memory usage caused by abandoned native-driven loops.

🔬 **Measurement:** 
- The React Profiler will show that when one `BreathingContainer` is clicked, the other sibling containers do not re-render.
- A native profiler (like Instruments or Android Studio Profiler) will show that CPU usage drops back to idle when all items are checked off instead of staying active.

---
*PR created automatically by Jules for task [5442315928392807467](https://jules.google.com/task/5442315928392807467) started by @hkners*