### PR TITLE
⚡ Bolt: Fix Animated.loop resource leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Animated.loop Resource Leaks in React Native
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture the animation reference to prevent native thread resource leaks.
+      // Impact: Reduces potential background CPU usage and memory leaks from unstopped continuous animations.
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 **What**: Captured the `Animated.loop` reference in `App.js` and explicitly called `.stop()` in the `useEffect` cleanup function. Added critical learning about React Native animation resource leaks to `.jules/bolt.md`.
🎯 **Why**: In React Native, `Animated.loop` continues running indefinitely on the native thread (especially when `useNativeDriver: true`) even if the conditional logic changes or the component unmounts, leading to continuous background CPU usage and potential resource leaks.
📊 **Impact**: Prevents infinite background animations, reducing unnecessary native thread processing and improving overall application efficiency.
🔬 **Measurement**: CPU profiling via React Native debugger or native profilers (Xcode Instruments/Android Studio Profiler) will show halted animation threads when the intention priority changes or the component unmounts.

---
*PR created automatically by Jules for task [2821121183146776415](https://jules.google.com/task/2821121183146776415) started by @hkners*