### PR TITLE
🎨 Palette: Add accessibility attributes to custom checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Custom Checkbox Accessibility
+**Learning:** In React Native, custom interactive elements (e.g., `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning and must explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` or `accessibilityHint` for assistive technologies to work correctly.
+**Action:** Always add explicit semantic accessibility attributes to custom toggle components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added explicit `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` props to the custom `TouchableOpacity` toggle component in `App.js`.
🎯 Why: In React Native, custom interactive elements acting like checkboxes lack inherent semantic meaning. This ensures screen readers can correctly identify the component as a checkbox and read its current completed state.
📸 Before/After: Visuals remain unchanged. Semantic structure improved.
♿ Accessibility: Assistive technologies will now properly announce the element's title and checked status.

---
*PR created automatically by Jules for task [11521756291417815450](https://jules.google.com/task/11521756291417815450) started by @hkners*