### PR TITLE
🎨 Palette: Add accessibility props to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Custom Checkbox Accessibility
+**Learning:** In React Native, custom interactive elements (e.g., TouchableOpacity functioning as a checkbox) lack inherent semantic meaning and must explicitly declare accessibilityRole, accessibilityState, and accessibilityLabel or accessibilityHint for assistive technologies to work correctly.
+**Action:** Always add accessibilityRole="checkbox", accessibilityState={{ checked: ... }}, accessibilityLabel, and accessibilityHint to custom toggle elements.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={intention.completed ? 'Marks intention as incomplete' : 'Marks intention as complete'}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` props to the custom `TouchableOpacity` intention toggle in `App.js`. Created `.jules/palette.md` to document the learning that custom interactive elements require explicit ARIA props.
🎯 Why: To make the intention list usable and understandable for users relying on screen readers, as `TouchableOpacity` does not provide semantic meaning by default.
📸 Before/After: Visuals are unchanged as this is purely a semantic HTML/ARIA level improvement.
♿ Accessibility: Custom toggle components are now properly announced as checkboxes by assistive technologies, conveying their title and current checked state.

---
*PR created automatically by Jules for task [12761690232502518886](https://jules.google.com/task/12761690232502518886) started by @hkners*