### PR TITLE
🎨 Palette: Add accessibility attributes to custom checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Semantic Roles for Custom Checkboxes in React Native
+**Learning:** Custom interactive elements in React Native (like `TouchableOpacity` acting as a checkbox) lack inherent semantic meaning and require explicit `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` for screen readers to interpret them correctly. Also, continuous animations (like `Animated.loop`) can cause issues for automated interaction tools waiting for element stability.
+**Action:** Always add semantic accessibility props to custom UI components functioning as standard controls (e.g., checkboxes, radios) to ensure they are accessible to assistive technologies. Use `force=True` in Playwright when interacting with continuously animating elements.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={"Intention: " + intention.title}
+        accessibilityHint="Toggles intention completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added React Native accessibility props (`accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, `accessibilityLabel`, and `accessibilityHint`) to the custom intention toggle buttons.
🎯 Why: Custom interactive elements like `TouchableOpacity` do not inherently convey semantic meaning to screen readers. Adding these props ensures visually impaired users understand the control's purpose and state.
📸 Before/After: Visual appearance is unchanged, but semantic underlying accessibility is dramatically improved.
♿ Accessibility: Improved screen reader support by giving meaning and state to otherwise generic touchable areas.

---
*PR created automatically by Jules for task [4073508510996718902](https://jules.google.com/task/4073508510996718902) started by @hkners*