### PR TITLE
🎨 Palette: Add semantic accessibility props to intention checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Interactive element semantic accessibility needs in React Native
+**Learning:** Custom interactive elements (e.g. `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning and do not communicate state to screen readers by default. Setting `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and `accessibilityLabel` or `accessibilityHint` is critical for assistive technologies to correctly interpret the component's function and current status.
+**Action:** Always add semantic accessibility props to custom interactable containers that behave like standard UI controls.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
🎨 **What:** Added standard React Native accessibility props (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the `TouchableOpacity` component within the `BreathingContainer`.
🎯 **Why:** Custom interactive elements like `TouchableOpacity` functioning as checkboxes lack inherent semantic meaning and do not communicate their function or state to screen readers by default. This makes the interface more intuitive and accessible for assistive technology users.
📸 **Before/After:** No visual changes were made.
♿ **Accessibility:** Screen readers will now announce the element as a "checkbox", correctly report whether it is "checked" or not, read the intention's title as its label, and provide a hint on how to interact with it.

---
*PR created automatically by Jules for task [11994968826645826313](https://jules.google.com/task/11994968826645826313) started by @hkners*