### PR TITLE
🎨 Palette: Add accessibility semantics to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add Accessibility Semantics to Custom Interactive Elements
+**Learning:** Custom interactive elements (like `TouchableOpacity` acting as a checkbox) lack inherent semantic meaning for assistive technologies in React Native.
+**Action:** Explicitly declare `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and `accessibilityLabel` or `accessibilityHint` on custom controls to ensure they are properly interpreted by screen readers.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to toggle intention ${intention.completed ? 'off' : 'on'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the `TouchableOpacity` component in `BreathingContainer`.
🎯 **Why:** Custom interactive elements like `TouchableOpacity` lack inherent semantic meaning for assistive technologies. This change ensures screen readers correctly interpret the intention toggle as a checkbox and accurately report its checked state.
♿ **Accessibility:** Screen readers will now announce "Morning Meditation, checkbox, checked/unchecked. Double tap to toggle intention on/off." instead of just "Morning Meditation".

---
*PR created automatically by Jules for task [12515236235980617130](https://jules.google.com/task/12515236235980617130) started by @hkners*