### PR TITLE
🎨 Palette: Added accessibility attributes to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-03 - Added missing accessibility attributes to custom interactive element
+**Learning:** Custom interactive elements in React Native (like `TouchableOpacity` acting as a checkbox) lack semantic meaning and must explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` or `accessibilityHint` for assistive technologies to work correctly.
+**Action:** When implementing custom toggle/checkbox components using generic touchable wrappers, always explicitly define the appropriate accessibility props to ensure screen readers can announce their state and purpose.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={intention.completed ? "Tap to unmark as completed" : "Tap to mark as completed"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the TouchableOpacity component in BreathingContainer.
🎯 Why: To ensure screen readers can correctly announce the intention toggles as checkboxes and convey their checked/unchecked state to visually impaired users.
📸 Before/After: Visuals unchanged.
♿ Accessibility: Custom interactive element now correctly maps to native accessibility roles, making the core flow accessible.

---
*PR created automatically by Jules for task [16295170043556238835](https://jules.google.com/task/16295170043556238835) started by @hkners*