### PR TITLE
⚡ Bolt: Stop Animated.loop on cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-03 - Resource Leaks from Animated.loop
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capturing the loop reference to explicitly stop it on cleanup
+    // Impact: Prevents memory leaks and reduces CPU usage from orphaned native animations
+    let animationLoop;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animationLoop = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animationLoop.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animationLoop) {
+        animationLoop.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
What: Captures the reference to `Animated.loop` and explicitly calls `.stop()` when the `useEffect` cleanup function runs or dependencies change.
Why: Prevents resource and memory leaks from orphaned native animations continuing to run indefinitely.
Impact: Reduces background CPU usage and prevents cumulative memory leaks over time.
Measurement: Verified behavior with local testing and recorded the codebase-specific learning in the `.jules/bolt.md` journal.

---
*PR created automatically by Jules for task [10459612908765078085](https://jules.google.com/task/10459612908765078085) started by @hkners*