### PR TITLE
🎨 Palette: Add semantic roles to checkable intentions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-04 - Missing Semantic Roles on Custom Checkable Elements
+**Learning:** The `BreathingContainer` component in this app uses `TouchableOpacity` to create custom toggleable list items (acting as checkboxes), but completely lacks semantic meaning (`accessibilityRole`, `accessibilityState`). Screen readers announce these simply as "button" or "clickable" without indicating their checked state.
+**Action:** When creating custom toggleable elements (like checkboxes) in React Native using `TouchableOpacity`, always explicitly declare `accessibilityRole="checkbox"`, provide the current `accessibilityState={{ checked: ... }}`, and include clear `accessibilityLabel` and `accessibilityHint` so assistive tech can correctly announce the element's purpose and state.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Marks intention as ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
🎨 Palette: Add semantic roles to checkable intentions

- Added `accessibilityRole="checkbox"` to custom intentions list items.
- Added `accessibilityState={{ checked: ... }}` to indicate completion status.
- Provided `accessibilityLabel` and `accessibilityHint` for better screen reader announcements.
- Maintained clean visual aesthetic without side effects.
- Recorded learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7073433953691376218](https://jules.google.com/task/7073433953691376218) started by @hkners*