### PR TITLE
⚡ Bolt: Stop Animated.loop to prevent resource leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-04 - Animated.loop Resource Leak
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capturing Animated.loop reference and returning a cleanup function to call .stop()
+    // Impact: Prevents continuous animation running on the native thread after condition changes or unmount, saving CPU/battery.
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captures the `Animated.loop` reference and explicitly calls `.stop()` in the `useEffect` cleanup function.
🎯 Why: In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes or the component unmounts.
📊 Impact: Prevents continuous animation running on the native thread after condition changes or unmount, saving CPU/battery.
🔬 Measurement: Verify by observing the CPU usage or native bridge traffic when toggling intentions.

---
*PR created automatically by Jules for task [12646523514434633214](https://jules.google.com/task/12646523514434633214) started by @hkners*