### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-05 - Custom Checkbox Accessibility in React Native
+**Learning:** Custom interactive elements (like `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning and must explicitly declare `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and `accessibilityLabel` for assistive technologies to work correctly.
+**Action:** Always add explicit accessibility roles, states, and labels to custom interactive elements.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={"Toggles intention " + (intention.completed ? "off" : "on")}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the `TouchableOpacity` component in `BreathingContainer`.
🎯 Why: Custom interactive elements in React Native lack inherent semantic meaning. Without these attributes, screen reader users would not know the element functions as a checkbox or what its current state is.
📸 Before/After: Visuals remain unchanged (Clean Girl aesthetic preserved). Accessibility tree now properly exposes the elements as checkboxes with their respective labels and checked states.
♿ Accessibility: Assistive technologies can now correctly announce the intention toggles as checkboxes, announce their current completed state, and provide hints on how to interact with them.

---
*PR created automatically by Jules for task [17349657096501408172](https://jules.google.com/task/17349657096501408172) started by @hkners*