### PR TITLE
🎨 Palette: Add explicit accessibility roles to interactive intentions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-06 - TouchableOpacity Checkbox Accessibility
+**Learning:** In React Native, `TouchableOpacity` elements acting as custom checkboxes lack inherent semantic meaning for screen readers and do not automatically expose state. They require explicit `accessibilityRole="checkbox"`, `accessibilityState={{ checked: boolean }}`, and a clear `accessibilityLabel` to be correctly interpreted by assistive technologies.
+**Action:** Always manually apply `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` when using interactive components like `TouchableOpacity` or `Pressable` for state-toggling custom controls.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={intention.completed ? "Tap to mark as incomplete" : "Tap to mark as complete"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
**💡 What:** Added essential accessibility properties (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the interactive intentions (`TouchableOpacity`) in `App.js`. Also recorded this learning in the agent journal `.jules/palette.md`.
**🎯 Why:** In React Native, custom UI elements like `TouchableOpacity` functioning as checkboxes lack inherent semantic meaning. Assistive technologies need explicit roles and states to communicate the UI properly to visually impaired users.
**📸 Before/After:** N/A (Visuals remain identical).
**♿ Accessibility:** Screen readers will now announce the intentions as checkboxes, read their specific titles, correctly identify if they are checked/unchecked, and provide hints on how to interact with them.

---
*PR created automatically by Jules for task [16013428363289395411](https://jules.google.com/task/16013428363289395411) started by @hkners*