### PR TITLE
⚡ Bolt: Fix Animated.loop resource leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Animated.loop Resource Leak
+**Learning:** In React Native, Animated.loop continues running indefinitely on the native thread (when useNativeDriver: true) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call .stop() in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capture the animation reference to explicitly stop it on cleanup or condition change.
+    // Impact: Prevents memory and CPU resource leaks caused by indefinitely running native animations when they are no longer needed.
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
⚡ Bolt: Fix Animated.loop resource leak

**What**: Captured the `Animated.loop` reference and added a cleanup function to explicitly call `.stop()`.
**Why**: In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component unmounts or the effect condition changes, causing a resource leak.
**Impact**: Prevents memory and CPU leaks, improving overall app performance over time.
**Measurement**: Verified via source code inspection that the loop is correctly stopped on cleanup.

---
*PR created automatically by Jules for task [4835312320833261960](https://jules.google.com/task/4835312320833261960) started by @hkners*