### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-08 - Added Checkbox Accessibility to Interactive Views
+**Learning:** Custom interactive elements (e.g., TouchableOpacity functioning as a checkbox) lack inherent semantic meaning and must explicitly declare accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint for assistive technologies.
+**Action:** Always verify custom toggles have the appropriate semantic roles and state labels when behaving as checkboxes.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={intention.completed ? "Tap to mark as uncompleted" : "Tap to mark as completed"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibility attributes to the intention toggles.
🎯 Why: The custom `TouchableOpacity` lacked semantic meaning, making it inaccessible for screen readers.
📸 Before/After: Visuals remain unchanged, but structural semantic meaning was added.
♿ Accessibility: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to correctly identify the components as checkboxes to assistive technologies.

---
*PR created automatically by Jules for task [16728850613118874158](https://jules.google.com/task/16728850613118874158) started by @hkners*