### PR TITLE
⚡ Bolt: Stop Animated.loop in cleanup function

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-08 - Unstopped Animated.loop Leaks on Native Thread
+**Learning:** In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component state changes, leading to resource/memory leaks if not explicitly stopped.
+**Action:** Always capture the animation object returned by `Animated.loop(...)` and call `.stop()` in the `useEffect` cleanup function before starting a new animation or unmounting.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture Animated.loop reference and stop in cleanup
+      // Impact: Prevents memory leaks and wasted CPU cycles on the native thread caused by animations continuing indefinitely after unmount or state change.
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 **What:** Added logic to capture the `Animated.loop` reference inside `useEffect` and strictly call `.stop()` on it within the cleanup function in `App.js`.
🎯 **Why:** In React Native, `Animated.loop` animations configured with `useNativeDriver: true` will continue to run perpetually on the native UI thread, bypassing the JS thread. If they aren't explicitly stopped, they continue consuming CPU cycles and memory long after the component has unmounted or its internal state condition has changed.
📊 **Impact:** Prevents native thread resource leaks and wasted CPU cycles.
🔬 **Measurement:** Verify by running standard React Native memory/performance profilers during animation toggling and unmounting, or by observing decreased idle CPU usage on the native thread.

---
*PR created automatically by Jules for task [11237158012778713706](https://jules.google.com/task/11237158012778713706) started by @hkners*