### PR TITLE
🎨 Palette: Add accessibility props to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-09 - React Native Custom Checkbox Accessibility
+**Learning:** Custom interactive elements in React Native (like TouchableOpacity functioning as a checkbox) lack inherent semantic meaning and must explicitly declare accessibilityRole, accessibilityState, and accessibilityLabel or accessibilityHint for assistive technologies to work correctly.
+**Action:** Always add accessibilityRole="checkbox" and accessibilityState={{ checked: ... }} to TouchableOpacity components that toggle boolean state.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={`Double tap to mark as ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added explicitly semantic accessibility props (accessibilityRole="checkbox", accessibilityState, accessibilityLabel, accessibilityHint) to the custom intention toggle components (TouchableOpacity).
🎯 Why: React Native custom components lack inherent semantic meaning. Without these props, assistive technologies (like screen readers) cannot understand that these components function as interactive checkboxes that hold a specific checked/unchecked state, hindering usability for users relying on those technologies.
📸 Before/After: Visual appearance remains untouched, but screen reader output now correctly announces the component role, current state, and interaction hints.
♿ Accessibility: Improved screen reader support by correctly identifying custom toggles as checkboxes and announcing their current state (`completed`) along with instructions on how to toggle them.

---
*PR created automatically by Jules for task [935724985339522117](https://jules.google.com/task/935724985339522117) started by @hkners*