### PR TITLE
⚡ Bolt: Prevent memory leak in Animated.loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-09 - Prevent memory leak in Animated.loop
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -12,9 +12,12 @@ const INITIAL_INTENTIONS = [
 const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
+  // ⚡ Bolt: Capture animation reference and explicitly stop it on cleanup
+  // Impact: Prevents memory leaks by stopping infinite loops on unmount/re-render.
   useEffect(() => {
+    let anim;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      anim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      anim.start();
     } else {
       pulseAnim.setValue(1);
     }
+    return () => {
+      if (anim) {
+        anim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured `Animated.loop` reference and explicitly called `.stop()` in the `useEffect` cleanup function.
🎯 Why: In React Native, `Animated.loop` continues indefinitely on the native thread, causing a resource leak when components unmount or re-render.
📊 Impact: Prevents memory and CPU leaks by stopping infinite loops, reducing unnecessary background processing.
🔬 Measurement: Verify memory footprint stability in React DevTools/Profiler and confirm `pulseAnim` loop correctly stops when the item is completed or the priority changes.

---
*PR created automatically by Jules for task [12306683026035116934](https://jules.google.com/task/12306683026035116934) started by @hkners*