### PR TITLE
🎨 Palette: Add accessibility properties to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-10 - Explicit Accessibility for Custom Interactive Elements
+**Learning:** In React Native Web, custom interactive components like `TouchableOpacity` functioning as list toggles lack inherent semantic meaning and do not automatically expose state to screen readers.
+**Action:** Always explicitly declare `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and appropriate labels/hints to ensure screen reader compatibility.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added explicit accessibility properties (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the `TouchableOpacity` component functioning as a toggle in `App.js`.
🎯 Why: Custom interactive components in React Native Web like `TouchableOpacity` lack inherent semantic meaning, preventing screen readers from accurately conveying their purpose and state to users.
📸 Before/After: Visual appearance remains identical, but the component is now semantically a checkbox.
♿ Accessibility: Ensures that screen readers announce the element as a checkbox, read its specific intention title, and correctly indicate whether it is checked or unchecked.

---
*PR created automatically by Jules for task [14128390103459948641](https://jules.google.com/task/14128390103459948641) started by @hkners*