### PR TITLE
⚡ Bolt: Fix Animated.loop memory leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Animated.loop Memory Leak
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capturing animation reference and adding cleanup to prevent memory leaks from Animated.loop running indefinitely on the native thread
+      // Impact: Prevents orphaned native animations from consuming CPU/Memory after component updates/unmounts
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captures the `Animated.loop` reference and calls `.stop()` in a cleanup function.
🎯 Why: In React Native, `Animated.loop` with `useNativeDriver: true` can continue indefinitely on the native thread, causing resource leaks when the component unmounts or dependencies change.
📊 Impact: Prevents orphaned native animations from consuming CPU and memory.
🔬 Measurement: Verify that animations correctly stop when priority drops or the item is completed, and monitor memory usage over time.

---
*PR created automatically by Jules for task [324021026083890967](https://jules.google.com/task/324021026083890967) started by @hkners*