### PR TITLE
🎨 Palette: Improve accessibility of intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - React Native Custom Checkbox Accessibility
+**Learning:** In React Native, custom interactive elements (e.g., `TouchableOpacity` functioning as a checkbox) lack inherent semantic meaning. They must explicitly declare `accessibilityRole="checkbox"`, `accessibilityState={{ checked: ... }}`, and an `accessibilityLabel` or `accessibilityHint` for assistive technologies to work correctly. Without these, screen readers treat them as generic buttons without state.
+**Action:** Always add explicit ARIA/Accessibility props to custom interactive components that function as standard UI controls like checkboxes or radio buttons.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles completion of intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 **What:** Added comprehensive ARIA/accessibility properties (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the custom intention toggle buttons (`TouchableOpacity`) in `BreathingContainer`.
🎯 **Why:** Custom interactive elements in React Native (like `TouchableOpacity` acting as a checkbox) lack inherent semantic meaning for screen readers. By adding these properties, assistive technologies can now correctly announce the element as a checkbox, its current checked state, the intention's title, and how to interact with it.
📸 **Before/After:** No visual changes. Behavior for screen reader users drastically improved.
♿ **Accessibility:** Screen readers now announce: "Morning Meditation, checkbox, unchecked. Toggles completion of intention." instead of just generic "Button" or unintelligible tap targets.

---
*PR created automatically by Jules for task [8758186563744514142](https://jules.google.com/task/8758186563744514142) started by @hkners*