### PR TITLE
⚡ Bolt: Prevent Animated.loop resource leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - React Native Animated.loop Resource Leak
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capture animation reference to stop it properly on cleanup
+    // Impact: Prevents memory and CPU leaks from animations running indefinitely in the background on the native thread.
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the `Animated.loop` reference and added a `useEffect` cleanup function to explicitly call `.stop()` on unmount or dependency change.
🎯 Why: In React Native, `Animated.loop` runs indefinitely on the native thread (when `useNativeDriver: true`) even if the surrounding state condition changes to falsy, leading to CPU and memory leaks.
📊 Impact: Prevents animations from endlessly running in the background, reducing idle CPU usage and memory leaks over time.
🔬 Measurement: Observe memory and CPU profiles when interacting with the "BreathingContainer" component multiple times; idle resources will remain stable.

---
*PR created automatically by Jules for task [11214946610146192741](https://jules.google.com/task/11214946610146192741) started by @hkners*