### PR TITLE
🎨 Palette: [Accessibility roles to custom checkbox]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility Roles on Custom Checkboxes
+**Learning:** Custom interactive elements (like `TouchableOpacity` acting as checkboxes) in React Native lack semantic meaning and require explicit `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint` for assistive technologies to function correctly.
+**Action:** Always verify custom toggles and buttons have appropriate accessibility properties.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint="Toggles completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
🎨 Palette: Add accessibility roles to custom checkbox

💡 What: Added `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom intention toggles in `App.js`. Created `.jules/palette.md` to document the learning.
🎯 Why: Custom interactive elements (like `TouchableOpacity`) lack semantic meaning for screen readers. This makes the intention list navigable and understandable for users relying on assistive technologies.
📸 Before/After: Visuals remain unchanged, but structural markup is vastly improved.
♿ Accessibility: Transforms generic interactive elements into semantically meaningful checkboxes for screen readers.

---
*PR created automatically by Jules for task [13035515151372542775](https://jules.google.com/task/13035515151372542775) started by @hkners*