### PR TITLE
⚡ Bolt: Stop Animated.loop to prevent native thread resource leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-12 - Prevent Animated.loop resource leak
+**Learning:** In React Native, `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`) even if the condition changes, potentially causing resource leaks.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in a cleanup function within `useEffect` when it is no longer needed.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capture the animation loop reference to explicitly stop it
+    // Impact: Prevents memory leaks by stopping indefinite native animations when the intention state changes or component unmounts.
+    let loopAnim;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      loopAnim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      loopAnim.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (loopAnim) {
+        loopAnim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the `Animated.loop` reference and added a cleanup function to explicitly call `.stop()` when the intention state changes or the component unmounts.
🎯 Why: `Animated.loop` continues running indefinitely on the native thread (when `useNativeDriver: true`), which can cause resource leaks if not explicitly stopped.
📊 Impact: Prevents memory and CPU resource leaks by stopping indefinite native animations.
🔬 Measurement: Verify that animations still run when an intention is active, and ensure no background native thread load remains after completion or unmounting.

---
*PR created automatically by Jules for task [13022014666234142044](https://jules.google.com/task/13022014666234142044) started by @hkners*