### PR TITLE
🎨 Palette: Add accessibility roles to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Semantic Meaning in Custom Toggles
+**Learning:** In React Native Web, custom interactive elements like `TouchableOpacity` functioning as checkboxes lack inherent semantic meaning and do not automatically render with `role="checkbox"`. This breaks accessibility for screen readers.
+**Action:** Always explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel` or `accessibilityHint` for custom interactive elements to ensure assistive technologies can properly understand and interact with them.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Mark ${intention.title} as ${intention.completed ? 'incomplete' : 'completed'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom intention toggle components.
🎯 Why: In React Native Web, `TouchableOpacity` elements functioning as checkboxes lack inherent semantic meaning, breaking accessibility for screen readers.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen readers can now correctly identify the elements as checkboxes, read their current state (completed/incomplete), and understand the context of what they are toggling.

---
*PR created automatically by Jules for task [3065765637825047475](https://jules.google.com/task/3065765637825047475) started by @hkners*