### PR TITLE
🎨 Palette: Add accessibility roles to intention checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Custom Checkbox Accessibility
+**Learning:** Custom interactive elements like `TouchableOpacity` functioning as checkboxes lack inherent semantic meaning in this app and must explicitly declare `accessibilityRole`, `accessibilityState`, and `accessibilityLabel`/`accessibilityHint` for assistive technologies to work correctly.
+**Action:** Always add explicit accessibility properties to custom interactive components that behave like standard HTML controls.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={intention.completed ? "Double tap to mark as incomplete" : "Double tap to mark as complete"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added explicitly semantic accessibility props (`accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint`) to the custom `TouchableOpacity` component functioning as a checkbox.
🎯 Why: Custom interactive elements in React Native (like `TouchableOpacity`) lack inherent semantic meaning. Assistive technologies need explicit roles and states to correctly describe the element's purpose and status to users.
📸 Before/After: Visual appearance remains identical. Screen readers will now announce "Morning Meditation, checkbox, unchecked, Double tap to mark as complete".
♿ Accessibility: Improved screen reader support for the main interaction point of the application.

---
*PR created automatically by Jules for task [503536328508742684](https://jules.google.com/task/503536328508742684) started by @hkners*