### PR TITLE
⚡ Bolt: [performance improvement] Prevent Animated.loop resource leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - React Native Animated.loop Resource Leak
+**Learning:** In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread, even if the component unmounts or `useEffect` dependencies change. `pulseAnim.setValue(1)` does not stop the underlying loop.
+**Action:** Always capture the animation reference returned by `Animated.loop(...)` and explicitly call `.stop()` in the `useEffect` cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Prevent orphaned native animations and resource leaks
+      // by capturing the loop reference and stopping it on cleanup
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the `Animated.loop` reference in `App.js` and explicitly stopped it in the `useEffect` cleanup function.
🎯 Why: In React Native, `Animated.loop` with `useNativeDriver: true` continues running on the native thread even if the component unmounts or its `useEffect` dependencies change. `pulseAnim.setValue(1)` does not stop the underlying loop, leading to a resource leak and unnecessary battery drain.
📊 Impact: Eliminates orphaned background animations, resolving a native thread memory and CPU leak when intentions are completed or the component unmounts.
🔬 Measurement: Verified visually that the app continues to render and animate correctly, and that the cleanup function correctly fires to halt the native animation loop.

---
*PR created automatically by Jules for task [530919718642966822](https://jules.google.com/task/530919718642966822) started by @hkners*