### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility on TouchableOpacity as checkboxes
+**Learning:** In React Native, custom interactive elements built with `TouchableOpacity` that act as checkboxes must have explicit `accessibilityRole="checkbox"` and `accessibilityState={{ checked: ... }}` so screen readers can correctly interpret and announce their state.
+**Action:** Always add proper accessibility roles, states, labels, and hints to custom touchable components in React Native.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessible={true}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to toggle ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the custom intention toggle buttons.
🎯 Why: To make the custom `TouchableOpacity` buttons discoverable and their state understandable by screen readers.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen reader users can now identify the buttons as checkboxes and know if they are checked or unchecked.

---
*PR created automatically by Jules for task [10048725913636548717](https://jules.google.com/task/10048725913636548717) started by @hkners*