### PR TITLE
🎨 Palette: Add accessibility traits to custom toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-17 - Accessible Custom Checkboxes
+**Learning:** When using `TouchableOpacity` to create custom toggleable list items, screen readers do not automatically know the item is interactive or what its current state is.
+**Action:** Always add `accessibilityRole="checkbox"` and `accessibilityState={{ checked: <boolean> }}` to custom interactive components that function as toggles.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the intention completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the intention toggle buttons.
🎯 Why: To ensure screen readers correctly identify the list items as interactive checkboxes and announce their current completed state, making the app usable for visually impaired users.
📸 Before/After: N/A (non-visual accessibility change)
♿ Accessibility: Fixed critical issue where screen readers lacked context for custom toggle components.

---
*PR created automatically by Jules for task [1582254331733725336](https://jules.google.com/task/1582254331733725336) started by @hkners*