### PR TITLE
⚡ Bolt: Prevent Animated.loop memory leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - React Native Animated.loop Memory Leak
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,11 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture the animation reference and stop it in cleanup
+      // to prevent orphaned animations and native thread resource leaks.
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
### 💡 What
Captured the `Animated.loop` reference and explicitly called `.stop()` in the `useEffect` cleanup function within `App.js`. Added a journal entry logging this React Native specific performance learning.

### 🎯 Why
In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread. If the `useEffect` dependencies change (e.g., intention is marked completed) or the component unmounts, the orphaned animation continues consuming resources, leading to potential performance degradation and memory leaks over time.

### 📊 Impact
Prevents orphaned animations from running on the native thread indefinitely, avoiding background resource consumption and potential battery drain.

### 🔬 Measurement
Verified the app functions correctly and the animation accurately responds to priority and completion state changes. Since this prevents a background resource leak on the native thread over long sessions, it's measured via long-term stability and ensuring no active orphaned animations remain after the `useEffect` cleans up. No `pnpm test` or `lint` scripts are defined in `package.json` to run.

---
*PR created automatically by Jules for task [11374059501604494072](https://jules.google.com/task/11374059501604494072) started by @hkners*