### PR TITLE
⚡ Bolt: Prevent orphaned native animations memory leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Orphaned Native Animations Memory Leak
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,9 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +28,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      // ⚡ Bolt: Capture the animation reference and start it
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Cleanup function to stop orphaned animations on unmount or dependency change
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the `Animated.loop` reference in `BreathingContainer` and explicitly called `.stop()` in the `useEffect` cleanup function.
🎯 Why: In React Native, `Animated.loop` with `useNativeDriver: true` continues indefinitely on the native thread even after component unmount or dependency changes, causing a resource leak.
📊 Impact: Prevents orphaned native animations, freeing up native thread resources and reducing memory footprint.
🔬 Measurement: Verify by inspecting memory allocation and native thread performance in React Native profiler over extended use as high priority intentions are toggled.

---
*PR created automatically by Jules for task [7162374651300121735](https://jules.google.com/task/7162374651300121735) started by @hkners*