### PR TITLE
🎨 Palette: Add accessibility attributes to intention checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-21 - Custom Checkbox Accessibility
+**Learning:** Custom interactive elements built with `TouchableOpacity` that toggle state in this app are missing necessary screen reader context, making it impossible for visually impaired users to know their current state.
+**Action:** Always add `accessibilityRole="checkbox"` and `accessibilityState={{ checked: boolean }}` to `TouchableOpacity` components that function as toggles.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the intention toggle buttons.
🎯 Why: Screen readers could not previously determine the state of the intentions or that they were interactive checkboxes.
📸 Before/After: Visuals remain unchanged (internal a11y improvement).
♿ Accessibility: Ensures users with screen readers can understand and interact with the intention checklist properly.

---
*PR created automatically by Jules for task [13207997075889410202](https://jules.google.com/task/13207997075889410202) started by @hkners*