### PR TITLE
⚡ Bolt: Optimize BreathingContainer performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-21 - React Native Animated.loop Native Thread Leaks
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference (`const animation = Animated.loop(...)`) and explicitly call `animation.stop()` in the `useEffect` cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,14 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Added React.memo to prevent unnecessary re-renders when other intentions are toggled
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Explicitly stop animation on cleanup to prevent orphaned animations on the native thread
+    return () => {
+      if (animation) animation.stop();
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +65,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped in useCallback to maintain stable reference for React.memo
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added React.memo to BreathingContainer, wrapped toggleIntention in useCallback, and fixed a native thread memory leak by explicitly calling .stop() on Animated.loop during useEffect cleanup.
🎯 Why: Toggling any intention previously caused all BreathingContainers to re-render. Additionally, unmounted components left animations running on the native thread indefinitely.
📊 Impact: Reduces list item re-renders to only the toggled item. Eliminates orphaned native animations, improving memory efficiency.
🔬 Measurement: Verify with React DevTools Profiler that only toggled items re-render. Observe memory usage over time to confirm no animation leaks.

---
*PR created automatically by Jules for task [17122647927503477524](https://jules.google.com/task/17122647927503477524) started by @hkners*