### PR TITLE
⚡ Bolt: Prevent React list re-renders and animation leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Prevent Animated.loop native thread leaks
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -9,12 +9,14 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture the animation reference and stop it on cleanup to prevent orphaned animations and resource leaks on the native thread.
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +66,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize the toggle handler to prevent unnecessary re-renders of all BreathingContainer list items.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Memoized BreathingContainer with React.memo, memoized toggleIntention with React.useCallback, and fixed Animated.loop cleanup.
🎯 Why: Prevents unnecessary O(N) re-renders of all list items when one is toggled, and prevents indefinite native thread resource leaks from orphaned animations.
📊 Impact: Reduces re-renders by ~75% for list item toggles and prevents memory/CPU leaks on native thread.
🔬 Measurement: Verify with React DevTools Profiler that only the toggled item re-renders, and use native performance monitor to ensure CPU usage drops when animations are toggled off.

---
*PR created automatically by Jules for task [17989274458033116572](https://jules.google.com/task/17989274458033116572) started by @hkners*