### PR TITLE
🎨 Palette: Add accessibility to Intention toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-23 - Custom Checkbox Accessibility in React Native
+**Learning:** When creating custom interactive elements with TouchableOpacity that function as checkboxes or toggles, they lack built-in screen reader support. They must explicitly include accessibilityRole="checkbox" and accessibilityState={{ checked: <boolean> }} to properly communicate their function and state to assistive technologies.
+**Action:** Always add accessibilityRole and accessibilityState to custom toggle components to ensure proper screen reader support.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint={intention.completed ? "Tap to mark as uncompleted" : "Tap to mark as completed"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the Intention TouchableOpacity.
🎯 Why: Custom checkboxes need proper ARIA/accessibility props to be usable by screen readers.
📸 Before/After: Visuals unchanged.
♿ Accessibility: Screen readers will now announce the Intention as a checkbox and correctly report its checked/unchecked state.

---
*PR created automatically by Jules for task [9060583304261092812](https://jules.google.com/task/9060583304261092812) started by @hkners*