### PR TITLE
⚡ Bolt: Prevent native animation resource leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-23 - Native Animation Resource Leaks
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture animation reference to stop it properly and prevent native thread resource leaks
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      // ⚡ Bolt: Explicitly stop animation on cleanup to prevent orphaned native animations
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the `Animated.loop` reference and explicitly called `.stop()` in the `useEffect` cleanup function.
🎯 Why: In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component unmounts or dependencies change, causing resource leaks.
📊 Impact: Prevents orphaned native animations, reducing memory consumption and CPU usage over time.
🔬 Measurement: Verify memory usage doesn't continually increase when repeatedly toggling high-priority intentions.

---
*PR created automatically by Jules for task [6539762564720860876](https://jules.google.com/task/6539762564720860876) started by @hkners*