### PR TITLE
⚡ Bolt: Fix Animated.loop memory leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Animated.loop Memory Leak in React Native
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function of `useEffect` to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt Optimization: Capture animation ref to explicitly stop it and prevent native thread memory leaks
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Captured the animation reference and added a cleanup function to explicitly call `.stop()` in `BreathingContainer`.
🎯 Why: In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component unmounts or dependencies change, causing resource leaks.
📊 Impact: Prevents native thread orphaned animations, reducing memory usage and CPU load over time.
🔬 Measurement: Verify by observing the native thread's performance metrics and ensuring no redundant animation loops persist after intentions are marked completed or priority changes.

---
*PR created automatically by Jules for task [8288009565139541952](https://jules.google.com/task/8288009565139541952) started by @hkners*