### PR TITLE
🎨 Palette: Add accessibility roles to minimalist custom checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessible Minimalist Checkboxes
+**Learning:** In highly minimalist 'clean girl' designs, custom interactive containers (like `BreathingContainer`) often omit traditional visual checkmarks to maintain a spacious aesthetic. This creates an accessibility gap because the toggle state (e.g., strike-through text or opacity changes) is only communicated visually.
+**Action:** Always add `accessibilityRole="checkbox"` and `accessibilityState={{ checked: <boolean> }}` to these custom `TouchableOpacity` containers. This preserves the minimalist visual design while ensuring screen readers can correctly announce the interaction and current state.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the BreathingContainer's TouchableOpacity.
🎯 Why: To ensure the custom checkbox container is properly announced by screen readers as a toggleable checkbox, compensating for the lack of traditional visual checkmarks in minimalist designs.
📸 Before/After: N/A (Non-visual accessibility change)
♿ Accessibility: Ensures correct screen reader behavior by conveying the intention's checked state explicitly.

---
*PR created automatically by Jules for task [8377935188069189457](https://jules.google.com/task/8377935188069189457) started by @hkners*