### PR TITLE
⚡ Bolt: Prevent orphaned native animations memory leak

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Animated.loop Resource Leak in React Native
+**Learning:** When using `Animated.loop` with `useNativeDriver: true` in React Native, the animation runs indefinitely on the native thread. It does not automatically stop when the component unmounts or `useEffect` dependencies change, which leads to orphaned animations and resource leaks.
+**Action:** Always capture the animation reference returned by `Animated.loop()` and explicitly call `.stop()` in the cleanup function of the `useEffect`.

--- a/App.js
+++ b/App.js
@@ -13,8 +13,9 @@ const BreathingContainer = ({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +28,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Cleanup native animation to prevent memory leak and orphaned native threads
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {


### PR DESCRIPTION
💡 What: Explicitly call `.stop()` on `Animated.loop` in the cleanup function.
🎯 Why: Using `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change, causing resource leaks.
📊 Impact: Eliminates orphaned native animations and reduces memory leakage when intentions are marked completed.
🔬 Measurement: Profile the native thread CPU/memory usage before and after rapidly checking and unchecking high-priority intentions.

---
*PR created automatically by Jules for task [14542832834453060178](https://jules.google.com/task/14542832834453060178) started by @hkners*