### PR TITLE
🎨 Palette: Add accessibility roles to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing accessibility states in custom toggles
+**Learning:** Custom interactive elements (like the `BreathingContainer` functioning as a checkbox) in this app's React Native components often lack proper accessibility roles and states.
+**Action:** Always ensure `TouchableOpacity` components acting as toggles include `accessibilityRole="checkbox"` and `accessibilityState={{ checked: isChecked }}` for proper screen reader support.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles intention completion"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, and accessibilityLabel to the intention toggle buttons.
🎯 Why: Improves screen reader support so visually impaired users can understand the component acts as a checkbox.
📸 Before/After: Visuals remain unchanged, but screen readers now properly read the toggle state.
♿ Accessibility: Added ARIA-equivalent roles and states to TouchableOpacity.

---
*PR created automatically by Jules for task [635578339723390886](https://jules.google.com/task/635578339723390886) started by @hkners*