### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Animated Loop Resource Leak
+**Learning:** In React Native, when using `Animated.loop` with `useNativeDriver: true`, the animation continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change.
+**Action:** Always capture the animation reference and explicitly call `.stop()` in the cleanup function to prevent orphaned animations and resource leaks.

--- a/App.js
+++ b/App.js
@@ -9,12 +9,15 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+/* ⚡ Bolt Optimization: Wrap with React.memo to prevent unnecessary re-renders when other intentions are toggled */
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    /* ⚡ Bolt Optimization: Capture loop animation ref to stop it on cleanup and prevent native driver memory leak */
+    let loopAnim;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      loopAnim = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,17 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      loopAnim.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    return () => {
+      if (loopAnim) {
+        loopAnim.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +67,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  /* ⚡ Bolt Optimization: Memoize callback to pass stable reference to memoized children components */
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added React.memo and useCallback to prevent unnecessary re-renders of list items, and fixed a native Animated.loop memory leak by adding a stop() call in the useEffect cleanup.
🎯 Why: Without memoization, all items re-render when a single intention is toggled. Additionally, orphaned animations running on the native thread caused background resource consumption.
📊 Impact: Eliminates O(N-1) redundant component renders per interaction. Reclaims memory and CPU cycles by properly garbage-collecting background animations.
🔬 Measurement: Run React DevTools Profiler while toggling an intention to verify only the modified item re-renders. Check native thread CPU usage to confirm idle state when animations complete.

---
*PR created automatically by Jules for task [3343186462608107857](https://jules.google.com/task/3343186462608107857) started by @hkners*