### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-21 - React Native Animated.loop Memory Leaks
+**Learning:** In React Native, `Animated.loop` with `useNativeDriver: true` continues running on the native thread indefinitely even if the component unmounts or dependencies change, causing orphaned animations and resource leaks.
+**Action:** Always capture the `Animated.loop` instance and explicitly call `.stop()` in the `useEffect` cleanup function.

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,12 +9,15 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrap list items in memo to prevent unnecessary re-renders when other items update
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation; // ⚡ Bolt: Capture animation ref for cleanup
+
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,16 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Stop animation on cleanup to prevent memory leaks on native thread
+    return () => {
+      if (animation) animation.stop();
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +66,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize handler to preserve reference and enable BreathingContainer memoization
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Memoized `BreathingContainer` and its `toggleIntention` handler to prevent unnecessary re-renders of the entire list when a single item is updated. Added `.stop()` cleanup for `Animated.loop` to fix an orphaned native thread animation leak.
🎯 Why: Without `React.memo` and `useCallback`, clicking any intention triggers a full re-render of all list items. Furthermore, un-captured `Animated.loop` elements keep running on the native thread after unmount or condition changes, causing memory leaks.
📊 Impact: Reduces unnecessary re-renders of list items by 100% per interaction and prevents progressive memory bloat from orphaned animations.
🔬 Measurement: Open React Profiler and click an item to verify only the clicked item re-renders. Check memory allocations over time.

---
*PR created automatically by Jules for task [1558181737581682273](https://jules.google.com/task/1558181737581682273) started by @hkners*