### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Animated.loop Memory Leaks in React Native
+**Learning:** In React Native, `Animated.loop` with `useNativeDriver: true` continues running indefinitely on the native thread even if the component unmounts or `useEffect` dependencies change, causing orphaned animations and resource leaks.
+**Action:** Always capture the animation reference returned by `Animated.loop` and explicitly call `.stop()` in the `useEffect` cleanup function.

--- a/App.js
+++ b/App.js
@@ -9,12 +9,15 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders of the entire list
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    let animation;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      // ⚡ Bolt: Capture animation reference to prevent native thread memory leaks
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +30,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Explicitly stop animation on cleanup
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +68,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped in useCallback to maintain reference equality for React.memo
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo`, memoized `toggleIntention` with `React.useCallback`, and properly cleaned up `Animated.loop` on unmount.
🎯 Why: Prevents O(N) re-renders of the list when a single item is toggled. Fixes a memory leak where `Animated.loop` with `useNativeDriver: true` continued running on the native thread after unmount or effect update.
📊 Impact: Reduces unnecessary React re-renders by ~75% and prevents indefinite native thread resource consumption.
🔬 Measurement: Verify with React DevTools Profiler that only the toggled item re-renders, and use native memory profiling to ensure no orphaned animations exist after unmounting.

---
*PR created automatically by Jules for task [9386067701819842785](https://jules.google.com/task/9386067701819842785) started by @hkners*