### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders and memory leaks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-01 - Prevent Native Animation Leaks in Expo
+**Learning:** In Expo/React Native, using `Animated.loop` with `useNativeDriver: true` causes the animation to run indefinitely on the native thread. Even if the React component unmounts or the `useEffect` dependencies change, the native thread animation will leak if not explicitly stopped.
+**Action:** Always capture the animation reference returned by `Animated.loop()` and explicitly call `.stop()` on it within the `useEffect` cleanup function to prevent orphaned native animations.

--- a/App.js
+++ b/App.js
@@ -9,12 +9,14 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
+    // ⚡ Bolt: Capture animation reference to stop it properly and prevent memory leaks
+    let animation = null;
     if (intention.priority === 'high' && !intention.completed) {
-      Animated.loop(
+      animation = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
             toValue: 1.05,
@@ -27,10 +29,18 @@ const BreathingContainer = ({ intention, onToggle }) => {
             useNativeDriver: true,
           }),
         ])
-      ).start();
+      );
+      animation.start();
     } else {
       pulseAnim.setValue(1);
     }
+
+    // ⚡ Bolt: Cleanup function to stop orphaned animations
+    return () => {
+      if (animation) {
+        animation.stop();
+      }
+    };
   }, [intention.priority, intention.completed, pulseAnim]);
 
   const getContainerStyle = () => {
@@ -57,18 +67,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize the toggle function to prevent re-creating it on every render,
+  // which would break BreathingContainer's React.memo
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added React.memo and useCallback to prevent unnecessary re-renders of the list items, and stopped orphaned animations on unmount.
🎯 Why: Toggling a single item's completion status was triggering a re-render of all list items. Additionally, useNativeDriver loop animations can leak memory if not stopped.
📊 Impact: Reduces re-renders significantly for large lists and prevents native memory leaks.
🔬 Measurement: Test toggling an intention and measure the react profiler, verify no memory leaks occur when high priority item is toggled or unmounted.

---
*PR created automatically by Jules for task [10155903996398413592](https://jules.google.com/task/10155903996398413592) started by @hkners*