### PR TITLE
🎨 Palette: Add accessibility roles to intention toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-06 - React Native Custom Checkboxes
+**Learning:** Custom interactive elements in React Native (like `TouchableOpacity` acting as toggles) require explicit accessibility roles and states to be interpreted correctly by screen readers.
+**Action:** Always include `accessibilityRole="checkbox"` and `accessibilityState={{ checked: <boolean> }}` on custom toggle components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Toggle intention: ${intention.title}`}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole="checkbox", accessibilityState, and accessibilityLabel to the TouchableOpacity acting as a toggle.
🎯 Why: To improve screen reader support for the custom intentions toggle, ensuring it is properly identified as a checkbox and reflects its checked state.
📸 Before/After: Not applicable as this is a non-visual accessibility enhancement.
♿ Accessibility: Improved screen reader navigation and element identification by explicitly defining roles, states, and helpful hints.

---
*PR created automatically by Jules for task [3466000987248513008](https://jules.google.com/task/3466000987248513008) started by @hkners*