### PR TITLE
🎨 Palette: Add accessibility roles to intention toggles

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles completion status"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole="checkbox"`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the intention `TouchableOpacity`.
🎯 Why: To ensure screen readers correctly interpret the intention items as interactive checkboxes and announce their completion state.
📸 Before/After: No visual changes.
♿ Accessibility: Improves screen reader compatibility by explicitly defining the component's role and state.

---
*PR created automatically by Jules for task [14654711575921943371](https://jules.google.com/task/14654711575921943371) started by @hkners*