### PR TITLE
🎨 Palette: Add accessibility props to intention toggle

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to mark as ${intention.completed ? 'incomplete' : 'complete'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the intention toggle component.
🎯 Why: To ensure screen readers correctly interpret the intention toggle as a checkbox and announce its current state.
📸 Before/After: No visual changes.
♿ Accessibility: Improved screen reader support by providing explicit role, state, and interaction hints for custom interactive components.

---
*PR created automatically by Jules for task [11204904930084520726](https://jules.google.com/task/11204904930084520726) started by @hkners*