### PR TITLE
⚡ Bolt: Prevent unnecessary list item re-renders

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrapped in React.memo to prevent unnecessary re-renders.
+// Expected Impact: Reduces list item re-renders by ~75% when toggling a single intention.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized toggle handler with useCallback to maintain reference equality.
+  // Expected Impact: Prevents recreation of the function on every render, allowing React.memo to work effectively.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped the `BreathingContainer` component in `React.memo` and the `toggleIntention` handler in `React.useCallback` and added inline comments.
🎯 Why: To prevent all list items from unnecessarily re-rendering when a single intention's completion state is toggled.
📊 Impact: Eliminates redundant render cycles for unmodified list items, significantly improving list interaction performance.
🔬 Measurement: Verify using React DevTools Profiler by toggling an item and observing that only the modified item re-renders.

---
*PR created automatically by Jules for task [15957755363519265173](https://jules.google.com/task/15957755363519265173) started by @hkners*