### PR TITLE
🎨 Palette: Accessible Intention Toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Custom Toggle Accessibility
+**Learning:** Custom toggle components like intentions acting as checkboxes need explicit roles and states for screen readers, as `TouchableOpacity` defaults to a generic button role without checked states.
+**Action:** Always add `accessibilityRole="checkbox"` and `accessibilityState={{ checked: boolean }}` when implementing custom toggles.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={`Intention: ${intention.title}`}
+        accessibilityHint="Toggles the completion status of this intention"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added ARIA-equivalent accessibility roles and states to the custom Intention toggles.
🎯 Why: To ensure screen readers interpret the custom `TouchableOpacity` components as interactive checkboxes with explicit checked/unchecked states.
📸 Before/After: Non-visual change (accessibility only).
♿ Accessibility: Added `accessibilityRole="checkbox"`, `accessibilityState={{ checked: intention.completed }}`, `accessibilityLabel`, and `accessibilityHint` to the interactive intention containers.

---
*PR created automatically by Jules for task [1227452175011017645](https://jules.google.com/task/1227452175011017645) started by @hkners*