### PR TITLE
⚡ Bolt: Prevent unnecessary list item re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-12 - Functional state updates are crucial for React.useCallback optimizations
+**Learning:** When using `React.useCallback` to memoize a state update function (like `toggleIntention`), it is critical to use the functional state update form (`setIntentions(prev => ...)`) rather than depending on the current state. This allows the dependency array to remain empty (`[]`), ensuring the callback reference never changes, which is required for `React.memo` on child components to work properly.
+**Action:** Always prefer functional state updates inside `useCallback` when optimizing list item re-renders to guarantee stable function references and avoid stale closures.

--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrapped in React.memo to prevent unnecessary re-renders when other items toggle
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized callback prevents creating new function instances on every render,
+  // allowing React.memo on child components to work properly. Expected impact: O(1) render cost for un-toggled items.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and toggleIntention in React.useCallback.
🎯 Why: To prevent unnecessary re-renders of the entire list when only a single intention's state changes.
📊 Impact: Reduces re-renders of list items.
🔬 Measurement: Measure render times before and after toggling an intention.

---
*PR created automatically by Jules for task [4063158385326086280](https://jules.google.com/task/4063158385326086280) started by @hkners*