### PR TITLE
🎨 Palette: Add accessibility roles to intention checkboxes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+## Palette Journal

--- a/App.js
+++ b/App.js
@@ -50,6 +50,8 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole="checkbox"` and `accessibilityState={{ checked: intention.completed }}` to the custom `TouchableOpacity` intention components.
🎯 Why: To ensure screen readers correctly interpret the custom toggle components as checkboxes and announce their completed state, improving overall usability for visually impaired users.
📸 Before/After: N/A (Non-visual accessibility improvement)
♿ Accessibility: Custom interactive components acting as toggles now explicitly communicate their role and state to assistive technologies.

---
*PR created automatically by Jules for task [2253546303726936375](https://jules.google.com/task/2253546303726936375) started by @hkners*