### PR TITLE
⚡ Bolt: Memoize BreathingContainer

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent O(N) re-renders of the entire list when a single item is toggled.
+// Expected Impact: Reduces unnecessary React component renders for sibling list items by ~50% or more depending on list size.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized with useCallback to maintain reference equality across parent re-renders.
+  // Expected Impact: Ensures React.memo on BreathingContainer works correctly by passing the exact same function reference.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer with React.memo and memoized toggleIntention with React.useCallback.\n🎯 Why: To prevent re-rendering all intention list items when a single item's completion state is toggled.\n📊 Impact: Reduces unnecessary React component re-renders for list items by O(N).\n🔬 Measurement: Using React Developer Tools Profiler, verify that only the toggled item re-renders instead of the entire list.

---
*PR created automatically by Jules for task [14417510839946581023](https://jules.google.com/task/14417510839946581023) started by @hkners*