### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent re-rendering all list items when one is toggled
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized handler to maintain stable reference for React.memo children
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` handler with `React.useCallback`.
🎯 Why: Without memoization, all `BreathingContainer` items in the list re-render whenever the user toggles a single item, which is inefficient.
📊 Impact: Eliminates O(n) unnecessary item re-renders when toggling state, keeping list interaction fast.
🔬 Measurement: Use React DevTools Profiler to verify that only the toggled `BreathingContainer` re-renders while the rest skip rendering.

---
*PR created automatically by Jules for task [10353021638327563613](https://jules.google.com/task/10353021638327563613) started by @hkners*