### PR TITLE
🎨 Palette: Add accessibility roles and states to intention toggles

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to mark as ${intention.completed ? 'incomplete' : 'completed'}`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the intention `TouchableOpacity`.
🎯 Why: To ensure screen readers correctly interpret the intentions as checkboxes, allowing visually impaired users to understand the current completion state and how to interact with them.
📸 Before/After: N/A (Non-visual accessibility improvement)
♿ Accessibility: Made custom toggle interactive elements fully accessible to screen readers by declaring them as checkboxes with a dynamically updated checked state.

---
*PR created automatically by Jules for task [11327519953958111348](https://jules.google.com/task/11327519953958111348) started by @hkners*