### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoize the list item component to prevent unnecessary re-renders
+// Impact: O(1) rendering time for unchanged items instead of O(N) when list state updates
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,21 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize the toggle handler with an empty dependency array
+  // Since we use a functional state update, the callback reference never changes,
+  // preventing unnecessary re-renders of memoized child components
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and memoized toggleIntention using React.useCallback.
🎯 Why: To prevent unnecessary re-renders of the entire list when a single intention is toggled.
📊 Impact: Reduces re-renders from O(N) to O(1) when updating list item state.
🔬 Measurement: Use React Profiler to verify that unchanged list items no longer render when an intention is toggled.

---
*PR created automatically by Jules for task [1634189235991070170](https://jules.google.com/task/1634189235991070170) started by @hkners*