### PR TITLE
🎨 Palette: Add accessibility attributes to intention toggle

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint="Toggles intention completion"
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the intention `TouchableOpacity` component.
🎯 Why: To ensure the intention toggles are correctly announced and interpretable by screen readers as checkboxes.
📸 Before/After: N/A (Non-visual accessibility improvement)
♿ Accessibility: Screen reader users can now understand that the items are checkboxes, hear their completed state, and know that tapping them toggles their completion.

---
*PR created automatically by Jules for task [8341318369870143459](https://jules.google.com/task/8341318369870143459) started by @hkners*