### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrapped list item component in React.memo to prevent unnecessary re-renders when other items change.
+// Expected Impact: Reduces unnecessary re-renders of unaffected list items by 100% when toggling a single item.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized the toggle handler to maintain referential equality.
+  // Expected Impact: Combined with React.memo on the child, this prevents O(n) re-renders for list items on every state update.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and memoized toggleIntention with useCallback.
🎯 Why: To prevent all list items from unnecessarily re-rendering when only a single item's state changes.
📊 Impact: Reduces unnecessary re-renders of unaffected list items by 100% when toggling a single item.
🔬 Measurement: Verify by adding a console.log inside BreathingContainer and observing that only the toggled item logs on press, instead of all items.

---
*PR created automatically by Jules for task [3321344765377696321](https://jules.google.com/task/3321344765377696321) started by @hkners*