### PR TITLE
⚡ Bolt: Memoize List Items and Handlers

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoize the container to prevent unnecessary re-renders
+// when other items in the list update.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize the toggle handler to maintain stable reference
+  // and prevent child component re-renders.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and toggleIntention in React.useCallback.
🎯 Why: To prevent unnecessary re-renders of the entire intention list when only a single item's completed state changes.
📊 Impact: Eliminates O(n) component re-renders per toggle, reducing it to O(1) for the specifically updated item.
🔬 Measurement: Use React DevTools Profiler to verify that unchanged list items do not re-render upon clicking a specific intention.

---
*PR created automatically by Jules for task [1769550901412217415](https://jules.google.com/task/1769550901412217415) started by @hkners*