### PR TITLE
⚡ Bolt: Optimized List Item Re-renders

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders of the entire list when a single intention changes.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized callback using functional state updates to avoid stale closures.
+  // Keeps the dependency array empty so the reference never changes, optimizing child re-renders.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` handler with `React.useCallback`.
🎯 Why: To prevent all list items from re-rendering unnecessarily whenever a single intention's completed state is toggled.
📊 Impact: Eliminates redundant React reconciliations for unmodified sibling list items (O(1) updates instead of O(n)).
🔬 Measurement: Can be verified using the React DevTools Profiler by recording a state change and observing that only the modified component re-renders.

---
*PR created automatically by Jules for task [5337463310299256968](https://jules.google.com/task/5337463310299256968) started by @hkners*