### PR TITLE
⚡ Bolt: Refactored List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped list item component in React.memo() to prevent unnecessary re-renders when other items are toggled.
+// Expected Impact: O(1) list item re-rendering instead of O(N).
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped interaction handler in React.useCallback() with empty dependency array using functional state updates.
+  // Expected Impact: Maintains a stable reference for onToggle, ensuring child components using React.memo do not needlessly re-render.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and toggleIntention in React.useCallback.
🎯 Why: To prevent unnecessary re-renders of the entire list when only a single item's state changes.
📊 Impact: Reduces re-renders from O(N) to O(1) list item re-rendering.
🔬 Measurement: Using React DevTools Profiler, toggling an item now only renders the changed item.

---
*PR created automatically by Jules for task [16282391107483187401](https://jules.google.com/task/16282391107483187401) started by @hkners*