### PR TITLE
⚡ Bolt: Refactored List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoize list item to prevent unnecessary re-renders when other items are toggled
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize handler to maintain stable reference for React.memo child
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and `toggleIntention` in `React.useCallback`.
🎯 Why: To prevent unnecessary re-renders of the entire list when only a single item's state changes.
📊 Impact: Reduces list item re-renders to O(1) instead of O(N) upon item toggle.
🔬 Measurement: Profile React renders using React DevTools while toggling an intention.

---
*PR created automatically by Jules for task [4613047589719841934](https://jules.google.com/task/4613047589719841934) started by @hkners*