### PR TITLE
⚡ Bolt: Memoize List Item Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// Performance optimization: Wrap BreathingContainer in React.memo to prevent unnecessary re-renders.
+// Expected impact: Reduces list item re-renders by skipping reconciliation for unchanged intentions.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // Performance optimization: Memoize callback with empty dependency array using functional state update.
+  // Expected impact: Prevents BreathingContainer components from re-rendering when other items are toggled.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and `toggleIntention` in `React.useCallback`.
🎯 Why: To prevent all list items from unnecessarily re-rendering whenever a single item's state is toggled.
📊 Impact: Reduces list item re-renders by ~75% for an average list length of 4, saving main thread time.
🔬 Measurement: Verify with React DevTools Profiler that unchanged items skip render when an intention is toggled.

---
*PR created automatically by Jules for task [15870302940796743276](https://jules.google.com/task/15870302940796743276) started by @hkners*