### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoized to prevent re-renders of unmodified intentions during toggle
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: useCallback with empty deps prevents recreating this function on every render,
+  // allowing React.memo on BreathingContainer to work effectively.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and `toggleIntention` in `React.useCallback`.
🎯 Why: To prevent all `BreathingContainer` components from re-rendering whenever a single intention is toggled.
📊 Impact: Reduces O(N) re-renders to O(1) during toggle interaction, preventing performance drops in long lists.
🔬 Measurement: Use React DevTools Profiler to record a toggle interaction. Observe that only the toggled `BreathingContainer` re-renders, while unmodified ones are skipped.

---
*PR created automatically by Jules for task [6673249435045034667](https://jules.google.com/task/6673249435045034667) started by @hkners*