### PR TITLE
⚡ Bolt: Memoized Intention List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,11 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Performance Optimization:
+// Wrapped in React.memo to prevent unnecessary re-renders.
+// Now only the specific item being toggled will re-render,
+// rather than all items in the list.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +61,22 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Performance Optimization:
+  // Memoized toggle handler to maintain stable reference across renders.
+  // When combined with React.memo on BreathingContainer, this prevents O(n) unnecessary
+  // re-renders of the entire list when a single item is toggled.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` handler using `React.useCallback`.
🎯 Why: Toggling a single intention previously caused the entire list of intentions to re-render because the handler reference changed and the container wasn't memoized.
📊 Impact: Reduces component re-renders from O(n) to O(1) when toggling an item, significantly improving scroll and interaction performance as the list grows.
🔬 Measurement: Verify by profiling component renders in React DevTools during toggle interactions. Only the toggled item should render.

---
*PR created automatically by Jules for task [11119411092673863974](https://jules.google.com/task/11119411092673863974) started by @hkners*