### PR TITLE
🎨 Palette: Intention Toggle Accessibility Improvement

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-31 - Intentions List Toggle Accessibility
+**Learning:** Custom toggle components built with `TouchableOpacity` require explicit ARIA-equivalent props for screen readers, unlike standard checkboxes.
+**Action:** Always include `accessibilityRole="checkbox"` and `accessibilityState={{ checked: boolean }}` when creating custom toggle/checkbox components.

--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={intention.completed ? "Marks intention as incomplete" : "Marks intention as complete"}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added accessibilityRole, accessibilityState, accessibilityLabel, and accessibilityHint to the intention toggle component.
🎯 Why: To improve screen reader accessibility so users can perceive the custom toggle as a checkbox and understand its current state and action.
📸 Before/After: N/A (non-visual change)
♿ Accessibility: Replaced standard TouchableOpacity props with explicit checkbox role and state for proper screen reader interpretation.

---
*PR created automatically by Jules for task [10306961206734685256](https://jules.google.com/task/10306961206734685256) started by @hkners*