### PR TITLE
⚡ Bolt: Memoized List Rendering for Intentions

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoized child component to prevent unnecessary re-renders when other list items update.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+}); // ⚡ Bolt Optimization: Closes React.memo
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized callback with empty dependency array using functional state update
+  // to ensure reference stability and prevent re-rendering of all memoized BreathingContainers on any toggle.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and memoized toggleIntention with React.useCallback.
🎯 Why: Toggling one intention would cause all BreathingContainer components in the list to re-render needlessly because the inline onToggle reference changed and the child component wasn't memoized.
📊 Impact: Prevents re-renders of unmodified list items, significantly reducing React render tree reconciliation overhead when interacting with the list.
🔬 Measurement: Can be verified using React Developer Tools Profiler by recording a toggle interaction; only the toggled item should render, others should show 'Did not render'.

---
*PR created automatically by Jules for task [13349986035651498277](https://jules.google.com/task/13349986035651498277) started by @hkners*