### PR TITLE
⚡ Bolt: Memoize List Items and Callbacks

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoized component to prevent re-renders when other list items change
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized callback with functional state update to maintain stable reference
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and toggleIntention in React.useCallback.
🎯 Why: Toggling a single intention previously caused the parent App component to recreate the toggleIntention callback, triggering unnecessary re-renders of all BreathingContainer components in the list.
📊 Impact: Reduces O(N) child component re-renders to O(1) when a single item is toggled.
🔬 Measurement: Use React Profiler to confirm only the toggled list item re-renders, while unchanged items maintain their memoized state.

---
*PR created automatically by Jules for task [4122682408626195962](https://jules.google.com/task/4122682408626195962) started by @hkners*