### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// Optimization: React.memo prevents re-rendering all list items when only one changes
+// Expected impact: O(n) re-renders reduced to O(1) on toggle
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // Optimization: Memoize toggle handler to prevent unnecessary child re-renders
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added React.memo to the BreathingContainer component and memoized the toggleIntention handler with useCallback.
🎯 Why: To prevent all list items from unnecessarily re-rendering whenever a single intention is toggled.
📊 Impact: Reduces O(n) re-renders to O(1) during toggle interactions, improving UI responsiveness.
🔬 Measurement: Verify by interacting with the toggles and observing reduced CPU usage/re-renders in a React profiler.

---
*PR created automatically by Jules for task [8281030891524799530](https://jules.google.com/task/8281030891524799530) started by @hkners*