### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoized BreathingContainer to prevent unnecessary re-renders of the entire list
+// Impact: O(1) rendering on toggle instead of O(N)
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized handler using useCallback with functional state update
+  // Impact: Keeps reference stable, preventing child component re-renders
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []); // Empty dependency array because we use functional state updates
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
`💡 What:` Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` handler using `React.useCallback` with an empty dependency array.
`🎯 Why:` To prevent unnecessary re-renders of the entire list of intention components whenever a single intention is toggled.
`📊 Impact:` Eliminates O(N) re-renders, where N is the number of intentions, by ensuring only the modified intention component re-renders. Reduces overall CPU cycle usage during state updates.
`🔬 Measurement:` Use React Native DevTools Profiler to record a render pass before and after this change; the memoized version will show fewer component updates.

---
*PR created automatically by Jules for task [6642874880165049453](https://jules.google.com/task/6642874880165049453) started by @hkners*