### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoized component to prevent re-renders of unchanged list items
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized callback with empty dependency array using functional state update
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and toggleIntention in React.useCallback.
🎯 Why: Toggling a single intention previously caused the entire list of unchanged intention components to needlessly re-render because a new function reference was passed on every App render.
📊 Impact: Reduces re-renders of unchanged list items from O(N) to O(1), improving responsiveness when interacting with the list.
🔬 Measurement: Use React DevTools Profiler to record toggling an intention. Verify that only the clicked item re-renders, while unchanged items show 'Did not render'.

---
*PR created automatically by Jules for task [9441565494839361321](https://jules.google.com/task/9441565494839361321) started by @hkners*