### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoized component to prevent unnecessary re-renders when other items toggle
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized handler with empty deps since it uses functional state update
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added React.memo to BreathingContainer and wrapped toggleIntention in useCallback with an empty dependency array.
🎯 Why: To prevent all intention items from unnecessarily re-rendering when only one item's completed state is toggled.
📊 Impact: Reduces re-renders by ~75% for unaffected list items during toggle interactions.
🔬 Measurement: Use React DevTools Profiler to observe component renders when toggling an intention; only the toggled item should re-render.

---
*PR created automatically by Jules for task [5266004870799937760](https://jules.google.com/task/5266004870799937760) started by @hkners*