### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoized BreathingContainer to prevent unnecessary re-renders of all list items when only one intention is toggled.
+// Expected Impact: Reduces re-renders of untoggled components by 100%.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoized toggleIntention with useCallback and functional state update.
+  // This keeps the function reference stable across renders, allowing React.memo on child components to work effectively.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` with `React.memo` and `toggleIntention` with `React.useCallback` using an empty dependency array.
🎯 Why: To prevent all intention items from unnecessarily re-rendering whenever a single intention's completion status is toggled.
📊 Impact: Reduces re-renders of untoggled list components by 100%, saving main thread CPU cycles.
🔬 Measurement: Verify by adding a `console.log` inside `BreathingContainer` and observing that only the toggled item logs upon interaction.

---
*PR created automatically by Jules for task [18003045384841939299](https://jules.google.com/task/18003045384841939299) started by @hkners*