### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoized BreathingContainer to prevent unnecessary re-renders of the entire list when a single intention is toggled.
+const BreathingContainer = memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,21 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrapped toggle handler in useCallback to keep reference stable,
+  // working with React.memo on BreathingContainer to avoid
+  // re-rendering all items when one is tapped.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and the toggleIntention handler in useCallback.
🎯 Why: To prevent unnecessary re-renders of all list items when a single intention's state is toggled.
📊 Impact: Reduces O(n) re-renders to O(1) by keeping sibling components from re-rendering, saving CPU cycles on interactions.
🔬 Measurement: Verify by checking React DevTools Profiler while toggling an item and observing that only the toggled BreathingContainer re-renders instead of the entire list.

---
*PR created automatically by Jules for task [234473714695493378](https://jules.google.com/task/234473714695493378) started by @hkners*