### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped with React.memo to prevent O(n) re-renders.
+// Impact: Only toggled items will re-render, saving main thread time.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized toggle callback to maintain stable reference across renders.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer with React.memo, used React.useCallback for toggleIntention, and added explanatory performance comments.
🎯 Why: To prevent all intention items from unnecessarily re-rendering whenever a single item's state changes, and to document the optimization as required.
📊 Impact: Eliminates O(n) component re-renders per toggle, saving main thread time.
🔬 Measurement: Use React DevTools Profiler to verify that clicking an intention only re-renders App and the toggled BreathingContainer.

---
*PR created automatically by Jules for task [7274494310696847023](https://jules.google.com/task/7274494310696847023) started by @hkners*