### PR TITLE
⚡ Bolt: Memoized Breathing Container List

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Wrap list item in React.memo to prevent unnecessary re-renders
+// when siblings are toggled.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize toggle callback with functional state update
+  // to maintain a stable reference and enable React.memo to work properly on list items.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and memoized toggleIntention using React.useCallback, added comments explaining the optimizations, and removed a stray test file.
🎯 Why: To prevent all BreathingContainer items from re-rendering when only a single item's completion state changes.
📊 Impact: Reduces unnecessary re-renders of list items by O(N), improving rendering performance during list interactions.
🔬 Measurement: Verify with React DevTools Profiler that interacting with one item does not cause siblings to re-render.

---
*PR created automatically by Jules for task [5518360243159766365](https://jules.google.com/task/5518360243159766365) started by @hkners*