### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Optimization: Memoize component to prevent unnecessary re-renders of the entire list when a single intention is toggled.
+// Expected impact: Eliminates O(N) re-renders, making the list rendering O(1) per toggle interaction.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Optimization: Memoize toggle callback to maintain reference equality across App re-renders.
+  // Expected impact: Allows React.memo on child components to function correctly.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer in React.memo and memoized toggleIntention with useCallback.
🎯 Why: Toggling a single intention previously caused the entire list of BreathingContainers to re-render, leading to unnecessary processing.
📊 Impact: Eliminates O(N) re-renders, making the list rendering O(1) per toggle interaction, improving responsiveness.
🔬 Measurement: Verify by interacting with list items and observing rendering behavior using React DevTools profiler.

---
*PR created automatically by Jules for task [3285908455859879023](https://jules.google.com/task/3285908455859879023) started by @hkners*