### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoize the BreathingContainer to prevent unnecessary re-renders
+// when other items in the list are toggled (reduces re-renders from O(N) to O(1)).
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Wrap toggleIntention in useCallback so its reference remains stable.
+  // This is required for React.memo on BreathingContainer to be effective.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Added `React.memo` to `BreathingContainer` and wrapped `toggleIntention` in `useCallback`.
🎯 Why: To prevent the entire list from re-rendering when a single intention is toggled.
📊 Impact: Reduces list item re-renders from O(N) to O(1) upon state changes.
🔬 Measurement: Verify by toggling an item and using React DevTools Profiler to ensure only the toggled item re-renders.

---
*PR created automatically by Jules for task [7191506657635822376](https://jules.google.com/task/7191506657635822376) started by @hkners*