### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent unnecessary re-renders of un-toggled items
+// 📊 Impact: O(1) re-render instead of O(n) for the list when a single item is toggled
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized with useCallback to maintain reference equality and support React.memo
+  // 📊 Impact: Prevents `BreathingContainer` from re-rendering due to new function references
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` with `React.memo` and `toggleIntention` with `useCallback`. Added performance metric comments.
🎯 Why: Prevents unnecessary re-renders of all list items when only one item's completion state changes.
📊 Impact: Reduces re-renders significantly for un-toggled items in the intention list.
🔬 Measurement: Verify with React DevTools Profiler that unchanged `BreathingContainer` components do not re-render when an item is toggled.

---
*PR created automatically by Jules for task [16308849804315452466](https://jules.google.com/task/16308849804315452466) started by @hkners*