### PR TITLE
⚡ Bolt: Memoized List Item Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,10 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt Performance Optimization:
+// Memoizing list item component to prevent unnecessary re-renders when other list items update.
+// Expected Impact: Reduces re-renders of unmodified list items from O(N) to O(1) on toggle.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +60,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt Performance Optimization:
+  // Memoizing the callback to maintain a stable reference, preventing child re-renders.
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and `toggleIntention` in `React.useCallback`.
🎯 Why: Prevents unnecessary re-renders of all list items when only one item's `completed` state is toggled.
📊 Impact: Reduces re-renders of unmodified list items from O(N) to O(1) on interaction.
🔬 Measurement: Verify by interacting with a single intention in the list; other items will not re-render.

---
*PR created automatically by Jules for task [14157439625173942387](https://jules.google.com/task/14157439625173942387) started by @hkners*