### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,7 +9,8 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoize component to prevent re-renders of unchanged list items
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +58,19 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize callback to maintain stable reference for child component
+  const toggleIntention = React.useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` in `React.memo` and memoized the `toggleIntention` callback with `React.useCallback`.
🎯 Why: To prevent unnecessary re-renders of the entire intention list when a single item is toggled, improving rendering efficiency.
📊 Impact: Reduces component re-renders for unchanged list items, improving performance.
🔬 Measurement: Can be verified using React DevTools Profiler by toggling an intention and observing that only the toggled item re-renders.

---
*PR created automatically by Jules for task [15238229635809832110](https://jules.google.com/task/15238229635809832110) started by @hkners*