### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Wrapped in React.memo to prevent re-rendering all list items when a single intention is toggled.
+// Expected impact: Eliminates O(N) redundant component re-renders per toggle action.
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized toggle handler to maintain referential equality across App renders.
+  // Expected impact: Allows React.memo on BreathingContainer to successfully bail out of renders.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
`💡 What:` Wrapped BreathingContainer in React.memo and memoized toggleIntention with useCallback.
`🎯 Why:` To prevent all list items from re-rendering when a single intention is toggled.
`📊 Impact:` Eliminates O(N) redundant component re-renders per toggle action.
`🔬 Measurement:` Profiling the React tree during toggle actions will show only the toggled intention re-rendering.

---
*PR created automatically by Jules for task [9117509129588849159](https://jules.google.com/task/9117509129588849159) started by @hkners*