### PR TITLE
🎨 Palette: Intention Toggle Accessibility Improvement

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={`Double tap to ${intention.completed ? 'unmark' : 'mark'} as completed`}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the intention `TouchableOpacity`.
🎯 Why: To make the intention toggle buttons fully accessible to screen reader users, allowing them to understand the element's purpose and state.
📸 Before/After: N/A (Non-visual change)
♿ Accessibility: The intention toggle is now properly announced as a checkbox with its checked state and a helpful hint for interaction.

---
*PR created automatically by Jules for task [16774979984793131582](https://jules.google.com/task/16774979984793131582) started by @hkners*