### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoized component to prevent unnecessary re-renders of list items
+// Expected impact: Only the toggled item re-renders, reducing render cost for the list
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoized callback to prevent breaking React.memo on BreathingContainer
+  // Expected impact: Callback reference stays stable across parent re-renders
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped BreathingContainer with React.memo and memoized toggleIntention with useCallback.
🎯 Why: To prevent all list items from re-rendering whenever a single item is toggled.
📊 Impact: Reduces O(n) re-renders to O(1) by only rendering the item whose state changed.
🔬 Measurement: Verify with React DevTools Profiler that non-toggled items do not re-render upon toggling a specific intention.

---
*PR created automatically by Jules for task [4119027925049297077](https://jules.google.com/task/4119027925049297077) started by @hkners*