### PR TITLE
⚡ Bolt: Memoized List Rendering

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import { StatusBar } from 'expo-status-bar';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { StyleSheet, Text, View, Animated, TouchableOpacity, ScrollView, SafeAreaView } from 'react-native';
 
 const INITIAL_INTENTIONS = [
@@ -9,7 +9,9 @@ const INITIAL_INTENTIONS = [
   { id: '4', title: 'Deep Work Session', priority: 'high', completed: false },
 ];
 
-const BreathingContainer = ({ intention, onToggle }) => {
+// ⚡ Bolt: Memoize BreathingContainer to prevent unnecessary re-renders of the entire list when a single intention is toggled.
+// Expected Impact: Reduces list item re-renders by ~75% for a 4-item list (O(N) -> O(1) renders).
+const BreathingContainer = React.memo(({ intention, onToggle }) => {
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -57,18 +59,20 @@ const BreathingContainer = ({ intention, onToggle }) => {
       </TouchableOpacity>
     </Animated.View>
   );
-};
+});
 
 export default function App() {
   const [intentions, setIntentions] = useState(INITIAL_INTENTIONS);
 
-  const toggleIntention = (id) => {
+  // ⚡ Bolt: Memoize toggleIntention to maintain referential equality across renders,
+  // ensuring React.memo on BreathingContainer works correctly.
+  const toggleIntention = useCallback((id) => {
     setIntentions(prev =>
       prev.map(item =>
         item.id === id ? { ...item, completed: !item.completed } : item
       )
     );
-  };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safeArea}>


### PR DESCRIPTION
💡 What: Wrapped `BreathingContainer` with `React.memo` and memoized `toggleIntention` with `useCallback`.
🎯 Why: Prevents unnecessary re-renders of all intention items when a single intention is toggled.
📊 Impact: Reduces list item re-renders from O(N) to O(1) per interaction.
🔬 Measurement: Use React Developer Tools Profiler to observe only the toggled item re-rendering instead of the entire list.

---
*PR created automatically by Jules for task [3286453621982859408](https://jules.google.com/task/3286453621982859408) started by @hkners*