### PR TITLE
🎨 Palette: Intention Toggle Accessibility Improvement

### DIFF
--- a/App.js
+++ b/App.js
@@ -50,6 +50,10 @@ const BreathingContainer = ({ intention, onToggle }) => {
         activeOpacity={0.8}
         onPress={() => onToggle(intention.id)}
         style={[styles.intentionContainer, getContainerStyle()]}
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: intention.completed }}
+        accessibilityLabel={intention.title}
+        accessibilityHint={intention.completed ? 'Marks the intention as incomplete' : 'Marks the intention as complete'}
       >
         <Text style={[styles.intentionText, { color: getTextColor(), textDecorationLine: intention.completed ? 'line-through' : 'none' }]}>
           {intention.title}


### PR DESCRIPTION
💡 What: Added `accessibilityRole`, `accessibilityState`, `accessibilityLabel`, and `accessibilityHint` to the intention toggle buttons.
🎯 Why: To make the intention list accessible to screen readers, allowing users with visual impairments to understand and interact with the intention items intuitively.
📸 Before/After: N/A (Non-visual structural accessibility change)
♿ Accessibility: Properly announced list items with their checked state and actionable hints.

---
*PR created automatically by Jules for task [10635994337851367221](https://jules.google.com/task/10635994337851367221) started by @hkners*